### PR TITLE
Fix: heroku pushエラー解決のためbundlerのバージョンを変更#5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ group :development, :test do
   # Email
   gem 'letter_opener_web'
   gem 'net-smtp'
+  gem 'net-imap'
+  gem 'net-pop'
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,14 @@ GEM
     msgpack (1.5.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -465,6 +473,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
+    strscan (3.0.4)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
@@ -530,6 +539,8 @@ DEPENDENCIES
   listen (~> 3.3)
   meta-tags
   mini_magick
+  net-imap
+  net-pop
   net-smtp
   pg (~> 1.1)
   pry-byebug
@@ -562,4 +573,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.7
+   2.3.10


### PR DESCRIPTION
## 概要
herokuの設定を行なった。mainブランチからでないとheroku push出来なさそうなのでマージする。
bundlerのバージョンを本ブランチでherokuに合わせた。