### PR TITLE
Add: トップページへのルーティングを追加#8

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
 Rails.application.routes.draw do
   root to: 'home#top'
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 概要
プルリクをマージした後にローカルのmainでpullしたところ、
追加したトップページへのルーティング消えてしまっていたため改めて追加。
原因は実装の順番が行ったり来たり前後してしまたっためだと思われる。
以後注意。
