### PR TITLE
Fix: herokuへpush時のエラー解決#48

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.6.2)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
@@ -437,6 +439,8 @@ GEM
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.1.0)
       ffi (~> 1.9)
+    sassc (2.1.0-x86_64-linux)
+      ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -528,6 +532,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   annotate


### PR DESCRIPTION
herokuへpush時に発生する `Failed to install gems via Bundler.`解決のため、
herokuとローカルのbundlerのバージョンを`bundle lock --add-platform x86_64-linux`で揃えた。