### PR TITLE
Fix:検索フォームのplacehodlerを修正#82

### DIFF
--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -19,17 +19,27 @@
         </th>
         <td><%= @brewery.address.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z') %></td>
       </tr>
+      
       <tr class="bg-gray-50">
         <th scope="row" class="py-4 px-6 whitespace-nowrap">
         <%= Brewery.human_attribute_name :phone_number %>:
         </th>
-        <td><%= @brewery.phone_number.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')  %></td>
+        <% if @brewery.phone_number %>
+        <td><%= @brewery.phone_number.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z') %></td>
+        <% else %>
+        <td>不明</td>
+        <% end %>
       </tr>
+      
       <tr class="bg-amber-100">
         <th scope="row" class="py-4 px-6 whitespace-nowrap">
         <%= Brewery.human_attribute_name :website_url %>:
         </th>
+        <% if @brewery.website_url %>
         <td><%= link_to @brewery.website_url, "#{@brewery.website_url}" %></td>
+        <% else %>
+        <td>不明</td>
+        <% end %>
       </tr>
     </tbody>
   </table>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= search_form_for @q, url: url do |f| %>
   <div class="p-10">
     <div class="mb-14">
-      <%= f.search_field :name_or_address_cont, class: "w-4/6 mr-8 p-4 pl-10 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500", placeholder: "醸造所名、住所等のキーワードを入力してください。" %>
+      <%= f.search_field :name_or_address_cont, class: "w-4/6 mr-8 p-4 pl-10 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500", placeholder: "キーワード検索" %>
       
       <%= f.select :liquor_type_eq,
             Brewery.liquor_types_i18n.invert.map{|key, value| [key, Brewery.liquor_types[value]]},

--- a/lib/tasks/get_brewery_photo_from_places_api.rake
+++ b/lib/tasks/get_brewery_photo_from_places_api.rake
@@ -1,3 +1,6 @@
+require 'open-uri'
+require "csv"
+
 namespace :get_brewery_photo_from_places_api do
   desc "PlacesAPIからbreweryの写真を取得、DB保存"
   task brewery_photo: :environment do


### PR DESCRIPTION
## 概要

- 検索フォームのplaceholderの文章が長く、スマホで見ると途切れてしまい格好悪いので短く修正。
- 電話番号不明の醸造所で詳細画面表示エラーが発生。情報が無いの時の条件分岐を追加。