### PR TITLE
Fix:日本地図の表示を修正#81

### DIFF
--- a/app/assets/stylesheets/search_from_japanmap.scss
+++ b/app/assets/stylesheets/search_from_japanmap.scss
@@ -452,92 +452,92 @@ a:hover {
 /****************************************
 	レスポンシブ
 ****************************************/
-// @media screen and (max-width: 776px) {
-// #japan-map {
-// 	display: flex;
-// 	width: 100%;
-// 	flex-wrap: wrap;
-// 	justify-content: space-around;
-// }
-// #japan-map p.area-title {
-// 	display: inline-block;
-// 	width: 100%;
-// 	font-size: 15px;
-// 	text-align: center;
-// 	margin-top: 1.5em;
-// 	margin-bottom: 1em;
-// 	color: #000000;
-// }
-// #hokkaido-touhoku, #kantou, #chubu, #kinki, #chugoku, #shikoku, #kyusyu {
-// 	display: block;
-// 	position: static;
-// 	margin: 0 1em 0 1em;
-// }
-// #japan-map div div.area {
-// 	display: block;
-// 	position: relative;
-// }
+@media screen and (max-width: 776px) {
+#japan-map {
+	display: flex;
+	width: 100%;
+	flex-wrap: wrap;
+	justify-content: space-around;
+}
+#japan-map p.area-title {
+	display: inline-block;
+	width: 100%;
+	font-size: 15px;
+	text-align: center;
+	margin-top: 1.5em;
+	margin-bottom: 1em;
+	color: #000000;
+}
+#hokkaido-touhoku, #kantou, #chubu, #kinki, #chugoku, #shikoku, #kyusyu {
+	display: block;
+	position: static;
+	margin: 0 1em 0 1em;
+}
+#japan-map div div.area {
+	display: block;
+	position: relative;
+}
 
-// #hokkaido-touhoku {
-// 	height: calc(265px + 4.5em);
-// }
-// #kantou {
-// 	height: calc(174px + 4.5em);
-// }
-// #chubu {
-// 	height: calc(211px + 4.5em);
-// }
-// #kinki {
-// 	height: calc(211px + 4.5em);
-// }
-// #chugoku {
-// 	height: calc(98px + 4.5em);
-// }
-// #shikoku {
-// 	height: calc(84px + 4.5em);
-// }
-// #kyusyu {
-// 	height: calc(247px + 4.5em);
-// }
+#hokkaido-touhoku {
+	height: calc(265px + 4.5em);
+}
+#kantou {
+	height: calc(174px + 4.5em);
+}
+#chubu {
+	height: calc(211px + 4.5em);
+}
+#kinki {
+	height: calc(211px + 4.5em);
+}
+#chugoku {
+	height: calc(98px + 4.5em);
+}
+#shikoku {
+	height: calc(84px + 4.5em);
+}
+#kyusyu {
+	height: calc(247px + 4.5em);
+}
 
-// } /* レスポンシブ max-776px */
-
-
-
-// @media screen and (max-width: 500px) {
-// #japan-map {
-// 	display: block;
-// 	width: 100%;
-// 	height: auto;
-// }
-// #hokkaido-touhoku, #kantou, #chubu, #kinki, #chugoku, #shikoku, #kyusyu {
-// 	display: flex;
-// 	flex-wrap: wrap;
-// 	width: 100%;
-// 	height: auto;
-// 	position: static;
-// 	margin-left: 0px;
-// 	margin-right: 0px;
-// }
-// #japan-map div div.area {
-// 	font-size: 14px;
-//  	display: flex;
-// 	flex-wrap: wrap;
-// 	width: 100%;
-// }
-// #japan-map div div.area a {
-// 	height: auto;
-// 	width: 25%;
-// }
-// #japan-map div div.area div {
-//  	display: block;
-// 	border-radius: 0px;
-// 	position: static;
-// 	height: auto;
-// 	font-size: 16px;
-// 	width: 100%;
-// 	padding: 0.5em 0.3em 0.5em 0.3em;
-// }
+} /* レスポンシブ max-776px */
 
 
-// } /* レスポンシブ max-500px */
+
+@media screen and (max-width: 500px) {
+#japan-map {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+#hokkaido-touhoku, #kantou, #chubu, #kinki, #chugoku, #shikoku, #kyusyu {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+	height: auto;
+	position: static;
+	margin-left: 0px;
+	margin-right: 0px;
+}
+#japan-map div div.area {
+	font-size: 14px;
+ 	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+#japan-map div div.area a {
+	height: auto;
+	width: 25%;
+}
+#japan-map div div.area div {
+ 	display: block;
+	border-radius: 0px;
+	position: static;
+	height: auto;
+	font-size: 16px;
+	width: 100%;
+	padding: 0.5em 0.3em 0.5em 0.3em;
+}
+
+
+} /* レスポンシブ max-500px */

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,4 +1,4 @@
-<div class="containter h-screen w-screen relative bg-center bg-cover bg-top-image bg-no-repeat">
+<div class="h-screen w-screen relative bg-center bg-cover bg-top-image bg-no-repeat">
   <div class="absolute w-full translate-y--2/4 translate-x--2/4">
     <p class="text-gray-700 text-base text-center px-6 bg-yellow-200 font-semibold leading-relaxed">※新型コロナウイルスの影響により工場見学を中止している醸造所がございます。</br>必ずホームページ等で最新の実施状況をご確認ください。</p> 
     <div class="text-2xl sm:text-4xl md:text-5xl  lg:text-5xl xl:text-5xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 
   <body class="flex flex-col min-h-screen">
       <%= render partial: "shared/header"  %>
-      <main class="grow">
+      <main class="flex-grow">
         <%= yield %>
       </main>
       <%= render partial: "shared/footer" %>

--- a/app/views/search_from_japanmap/index.html.erb
+++ b/app/views/search_from_japanmap/index.html.erb
@@ -1,194 +1,191 @@
 <% content_for :title, '場所から探す' %>
 
 <div class="bg-gradient-to-r from-cyan-300 bg-cover">
-  <div class="containter h-screen w-screen">
-    <h1 class="flex justify-center pt-16 pl-10 text-gray-600 text-2xl sm:text-3xl md:text-3xl lg:text-4xl xl:text-4xl font-semibold">✈️ 気になる都道府県をクリック🍻✨</h1>
+  <h1 class="flex justify-center pt-16 pl-10 text-gray-600 text-2xl sm:text-3xl md:text-3xl lg:text-4xl xl:text-4xl font-semibold">✈️ 気になる都道府県をクリック🍻✨</h1>
 
-    <div class="pt-14">
-      <div id="japan-map" class="clearfix">
-        <div id="hokkaido-touhoku" class="clearfix">
-          <p class="area-title">北海道・東北</p>
-          <div class="area">
-            <div id="hokkaido">
-              <%= link_to "北海道", breweries_path(q: { prefecture_eq: "北海道" }),class: "text-white" %>
-            </div>
-            <div id="aomori">
-              <%= link_to "青森", breweries_path(q: { prefecture_eq: "青森県" }),class: "text-white" %>
-            </div>
-            <div id="akita">
-              <%= link_to "秋田", breweries_path(q: { prefecture_eq: "秋田県" }),class: "text-white" %>
-            </div>
-            <div id="iwate">
-              <%= link_to "岩手", breweries_path(q: { prefecture_eq: "岩手県" }),class: "text-white" %>
-            </div>
-            <div id="yamagata">
-              <%= link_to "山形", breweries_path(q: { prefecture_eq: "山形県" }),class: "text-white" %>
-            </div>
-            <div id="miyagi">
-              <%= link_to "宮城", breweries_path(q: { prefecture_eq: "宮城県" }),class: "text-white" %>
-            </div>
-            <div id="fukushima">
-              <%= link_to "福島", breweries_path(q: { prefecture_eq: "福島県" }),class: "text-white" %>
-            </div>
+  <div class="pt-14">
+    <div id="japan-map" class="clearfix h-full w-full md:h-screen md:w-screen md:ml-44">
+      <div id="hokkaido-touhoku" class="clearfix">
+        <p class="area-title">北海道・東北</p>
+        <div class="area">
+          <div id="hokkaido">
+            <%= link_to "北海道", breweries_path(q: { prefecture_eq: "北海道" }),class: "text-white" %>
+          </div>
+          <div id="aomori">
+            <%= link_to "青森", breweries_path(q: { prefecture_eq: "青森県" }),class: "text-white" %>
+          </div>
+          <div id="akita">
+            <%= link_to "秋田", breweries_path(q: { prefecture_eq: "秋田県" }),class: "text-white" %>
+          </div>
+          <div id="iwate">
+            <%= link_to "岩手", breweries_path(q: { prefecture_eq: "岩手県" }),class: "text-white" %>
+          </div>
+          <div id="yamagata">
+            <%= link_to "山形", breweries_path(q: { prefecture_eq: "山形県" }),class: "text-white" %>
+          </div>
+          <div id="miyagi">
+            <%= link_to "宮城", breweries_path(q: { prefecture_eq: "宮城県" }),class: "text-white" %>
+          </div>
+          <div id="fukushima">
+            <%= link_to "福島", breweries_path(q: { prefecture_eq: "福島県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="kantou">
-          <p class="area-title">関東</p>
-          <div class="area">
-            <div id="gunma">
-              <%= link_to "群馬", breweries_path(q: { prefecture_eq: "群馬県" }),class: "text-white" %>
-            </div>
-            <div id="tochigi">
-              <%= link_to "栃木", breweries_path(q: { prefecture_eq: "栃木県" }),class: "text-white" %>
-            </div>
-            <div id="ibaraki">
-              <%= link_to "茨城", breweries_path(q: { prefecture_eq: "茨城県" }),class: "text-white" %>
-            </div>
-            <div id="saitama">
-              <%= link_to "埼玉", breweries_path(q: { prefecture_eq: "埼玉県" }),class: "text-white" %>
-            </div>
-            <div id="chiba">
-              <%= link_to "千葉", breweries_path(q: { prefecture_eq: "千葉県" }),class: "text-white" %>
-            </div>
-            <div id="tokyo">
-              <%= link_to "東京", breweries_path(q: { prefecture_eq: "東京県" }),class: "text-white" %>
-            </div>
-            <div id="kanagawa">
-              <%= link_to "神奈川", breweries_path(q: { prefecture_eq: "神奈川県" }),class: "text-white" %>
-            </div>
+      <div id="kantou">
+        <p class="area-title">関東</p>
+        <div class="area">
+          <div id="gunma">
+            <%= link_to "群馬", breweries_path(q: { prefecture_eq: "群馬県" }),class: "text-white" %>
+          </div>
+          <div id="tochigi">
+            <%= link_to "栃木", breweries_path(q: { prefecture_eq: "栃木県" }),class: "text-white" %>
+          </div>
+          <div id="ibaraki">
+            <%= link_to "茨城", breweries_path(q: { prefecture_eq: "茨城県" }),class: "text-white" %>
+          </div>
+          <div id="saitama">
+            <%= link_to "埼玉", breweries_path(q: { prefecture_eq: "埼玉県" }),class: "text-white" %>
+          </div>
+          <div id="chiba">
+            <%= link_to "千葉", breweries_path(q: { prefecture_eq: "千葉県" }),class: "text-white" %>
+          </div>
+          <div id="tokyo">
+            <%= link_to "東京", breweries_path(q: { prefecture_eq: "東京県" }),class: "text-white" %>
+          </div>
+          <div id="kanagawa">
+            <%= link_to "神奈川", breweries_path(q: { prefecture_eq: "神奈川県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="chubu" class="clearfix">
-          <p class="area-title">中部</p>
-          <div class="area">
-            <div id="nigata">
-              <%= link_to "新潟", breweries_path(q: { prefecture_eq: "新潟県" }),class: "text-white" %>
-            </div>
-            <div id="toyama">
-              <%= link_to "富山", breweries_path(q: { prefecture_eq: "富山県" }),class: "text-white" %>
-            </div>
-            <div id="ishikawa">
-              <%= link_to "石川", breweries_path(q: { prefecture_eq: "石川県" }),class: "text-white" %>
-            </div>
-            <div id="fukui">
-              <%= link_to "福井", breweries_path(q: { prefecture_eq: "福井県" }),class: "text-white" %>
-            </div>
-            <div id="nagano">
-              <%= link_to "長野", breweries_path(q: { prefecture_eq: "長野県" }),class: "text-white" %>
-            </div>
-            <div id="gifu">
-              <%= link_to "岐阜", breweries_path(q: { prefecture_eq: "岐阜県" }),class: "text-white" %>
-            </div>
-            <div id="yamanashi">
-              <%= link_to "山梨", breweries_path(q: { prefecture_eq: "山梨県" }),class: "text-white" %>
-            </div>
-            <div id="aichi">
-              <%= link_to "愛知", breweries_path(q: { prefecture_eq: "愛知県" }),class: "text-white" %>
-            </div>
-            <div id="shizuoka">
-              <%= link_to "静岡", breweries_path(q: { prefecture_eq: "静岡県" }),class: "text-white" %>
-            </div>
+      <div id="chubu" class="clearfix">
+        <p class="area-title">中部</p>
+        <div class="area">
+          <div id="nigata">
+            <%= link_to "新潟", breweries_path(q: { prefecture_eq: "新潟県" }),class: "text-white" %>
+          </div>
+          <div id="toyama">
+            <%= link_to "富山", breweries_path(q: { prefecture_eq: "富山県" }),class: "text-white" %>
+          </div>
+          <div id="ishikawa">
+            <%= link_to "石川", breweries_path(q: { prefecture_eq: "石川県" }),class: "text-white" %>
+          </div>
+          <div id="fukui">
+            <%= link_to "福井", breweries_path(q: { prefecture_eq: "福井県" }),class: "text-white" %>
+          </div>
+          <div id="nagano">
+            <%= link_to "長野", breweries_path(q: { prefecture_eq: "長野県" }),class: "text-white" %>
+          </div>
+          <div id="gifu">
+            <%= link_to "岐阜", breweries_path(q: { prefecture_eq: "岐阜県" }),class: "text-white" %>
+          </div>
+          <div id="yamanashi">
+            <%= link_to "山梨", breweries_path(q: { prefecture_eq: "山梨県" }),class: "text-white" %>
+          </div>
+          <div id="aichi">
+            <%= link_to "愛知", breweries_path(q: { prefecture_eq: "愛知県" }),class: "text-white" %>
+          </div>
+          <div id="shizuoka">
+            <%= link_to "静岡", breweries_path(q: { prefecture_eq: "静岡県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="kinki" class="clearfix">
-          <p class="area-title">近畿</p>
-          <div class="area">
-            <div id="kyoto">
-              <%= link_to "京都", breweries_path(q: { prefecture_eq: "京都府" }),class: "text-white" %>
-            </div>
-            <div id="shiga">
-              <%= link_to "滋賀", breweries_path(q: { prefecture_eq: "滋賀県" }),class: "text-white" %>
-            </div>
-            <div id="osaka">
-              <%= link_to "大阪", breweries_path(q: { prefecture_eq: "大阪府" }),class: "text-white" %>
-            </div>
-            <div id="nara">
-              <%= link_to "奈良", breweries_path(q: { prefecture_eq: "奈良県" }),class: "text-white" %>
-            </div>
-            <div id="mie">
-              <%= link_to "三重", breweries_path(q: { prefecture_eq: "三重県" }),class: "text-white" %>
-            </div>
-            <div id="wakayama">
-              <%= link_to "和歌山", breweries_path(q: { prefecture_eq: "和歌山県" }),class: "text-white" %>
-            </div>
-            <div id="hyougo">
-              <%= link_to "兵庫", breweries_path(q: { prefecture_eq: "兵庫県" }),class: "text-white" %>
-            </div>
+      <div id="kinki" class="clearfix">
+        <p class="area-title">近畿</p>
+        <div class="area">
+          <div id="kyoto">
+            <%= link_to "京都", breweries_path(q: { prefecture_eq: "京都府" }),class: "text-white" %>
+          </div>
+          <div id="shiga">
+            <%= link_to "滋賀", breweries_path(q: { prefecture_eq: "滋賀県" }),class: "text-white" %>
+          </div>
+          <div id="osaka">
+            <%= link_to "大阪", breweries_path(q: { prefecture_eq: "大阪府" }),class: "text-white" %>
+          </div>
+          <div id="nara">
+            <%= link_to "奈良", breweries_path(q: { prefecture_eq: "奈良県" }),class: "text-white" %>
+          </div>
+          <div id="mie">
+            <%= link_to "三重", breweries_path(q: { prefecture_eq: "三重県" }),class: "text-white" %>
+          </div>
+          <div id="wakayama">
+            <%= link_to "和歌山", breweries_path(q: { prefecture_eq: "和歌山県" }),class: "text-white" %>
+          </div>
+          <div id="hyougo">
+            <%= link_to "兵庫", breweries_path(q: { prefecture_eq: "兵庫県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="chugoku" class="clearfix">
-          <p class="area-title">中国</p>
-          <div class="area">
-            <div id="tottori">
-              <%= link_to "鳥取", breweries_path(q: { prefecture_eq: "鳥取県" }),class: "text-white" %>
-            </div>
-            <div id="okayama">
-              <%= link_to "岡山", breweries_path(q: { prefecture_eq: "岡山県" }),class: "text-white" %>
-            </div>
-            <div id="shimane">
-              <%= link_to "島根", breweries_path(q: { prefecture_eq: "島根県" }),class: "text-white" %>
-            </div>
-            <div id="hiroshima">
-              <%= link_to "広島", breweries_path(q: { prefecture_eq: "広島県" }),class: "text-white" %>
-            </div>
-            <div id="yamaguchi">
-              <%= link_to "山口", breweries_path(q: { prefecture_eq: "山口県" }),class: "text-white" %>
-            </div>
+      <div id="chugoku" class="clearfix">
+        <p class="area-title">中国</p>
+        <div class="area">
+          <div id="tottori">
+            <%= link_to "鳥取", breweries_path(q: { prefecture_eq: "鳥取県" }),class: "text-white" %>
+          </div>
+          <div id="okayama">
+            <%= link_to "岡山", breweries_path(q: { prefecture_eq: "岡山県" }),class: "text-white" %>
+          </div>
+          <div id="shimane">
+            <%= link_to "島根", breweries_path(q: { prefecture_eq: "島根県" }),class: "text-white" %>
+          </div>
+          <div id="hiroshima">
+            <%= link_to "広島", breweries_path(q: { prefecture_eq: "広島県" }),class: "text-white" %>
+          </div>
+          <div id="yamaguchi">
+            <%= link_to "山口", breweries_path(q: { prefecture_eq: "山口県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="shikoku" class="clearfix">
-          <p class="area-title">四国</p>
-          <div class="area">
-            <div id="kagawa">
-              <%= link_to "香川", breweries_path(q: { prefecture_eq: "香川県" }),class: "text-white" %>
-            </div>
-            <div id="ehime">
-              <%= link_to "愛媛", breweries_path(q: { prefecture_eq: "愛媛県" }),class: "text-white" %>
-            </div>
-            <div id="tokushima">
-              <%= link_to "徳島", breweries_path(q: { prefecture_eq: "徳島県" }),class: "text-white" %>
-            </div>
-            <div id="kouchi">
-              <%= link_to "高知", breweries_path(q: { prefecture_eq: "高知県" }),class: "text-white" %>
-            </div>
+      <div id="shikoku" class="clearfix">
+        <p class="area-title">四国</p>
+        <div class="area">
+          <div id="kagawa">
+            <%= link_to "香川", breweries_path(q: { prefecture_eq: "香川県" }),class: "text-white" %>
+          </div>
+          <div id="ehime">
+            <%= link_to "愛媛", breweries_path(q: { prefecture_eq: "愛媛県" }),class: "text-white" %>
+          </div>
+          <div id="tokushima">
+            <%= link_to "徳島", breweries_path(q: { prefecture_eq: "徳島県" }),class: "text-white" %>
+          </div>
+          <div id="kouchi">
+            <%= link_to "高知", breweries_path(q: { prefecture_eq: "高知県" }),class: "text-white" %>
           </div>
         </div>
+      </div>
 
-        <div id="kyusyu" class="clearfix">
-          <p class="area-title">九州・沖縄</p>
-          <div class="area">
-            <div id="fukuoka">
-              <%= link_to "福岡", breweries_path(q: { prefecture_eq: "福岡県" }),class: "text-white" %>
-            </div>
-            <div id="saga">
-              <%= link_to "佐賀", breweries_path(q: { prefecture_eq: "佐賀県" }),class: "text-white" %>
-            </div>
-            <div id="nagasaki">
-              <%= link_to "長崎", breweries_path(q: { prefecture_eq: "長崎県" }),class: "text-white" %>
-            </div>
-            <div id="oita">
-              <%= link_to "大分", breweries_path(q: { prefecture_eq: "大分県" }),class: "text-white" %>
-            </div>
-            <div id="kumamoto">
-              <%= link_to "熊本", breweries_path(q: { prefecture_eq: "熊本県" }),class: "text-white" %>
-            </div>
-            <div id="miyazaki">
-              <%= link_to "宮崎", breweries_path(q: { prefecture_eq: "宮崎県" }),class: "text-white" %>
-            </div>
-            <div id="kagoshima">
-              <%= link_to "鹿児島", breweries_path(q: { prefecture_eq: "鹿児島県" }),class: "text-white" %>
-            </div>
-            <div id="okinawa">
-              <%= link_to "沖縄", breweries_path(q: { prefecture_eq: "沖縄県" }),class: "text-white" %>
-            </div>
+      <div id="kyusyu" class="clearfix">
+        <p class="area-title">九州・沖縄</p>
+        <div class="area">
+          <div id="fukuoka">
+            <%= link_to "福岡", breweries_path(q: { prefecture_eq: "福岡県" }),class: "text-white" %>
+          </div>
+          <div id="saga">
+            <%= link_to "佐賀", breweries_path(q: { prefecture_eq: "佐賀県" }),class: "text-white" %>
+          </div>
+          <div id="nagasaki">
+            <%= link_to "長崎", breweries_path(q: { prefecture_eq: "長崎県" }),class: "text-white" %>
+          </div>
+          <div id="oita">
+            <%= link_to "大分", breweries_path(q: { prefecture_eq: "大分県" }),class: "text-white" %>
+          </div>
+          <div id="kumamoto">
+            <%= link_to "熊本", breweries_path(q: { prefecture_eq: "熊本県" }),class: "text-white" %>
+          </div>
+          <div id="miyazaki">
+            <%= link_to "宮崎", breweries_path(q: { prefecture_eq: "宮崎県" }),class: "text-white" %>
+          </div>
+          <div id="kagoshima">
+            <%= link_to "鹿児島", breweries_path(q: { prefecture_eq: "鹿児島県" }),class: "text-white" %>
+          </div>
+          <div id="okinawa">
+            <%= link_to "沖縄", breweries_path(q: { prefecture_eq: "沖縄県" }),class: "text-white" %>
           </div>
         </div>
-      </div><!-- japan-map -->
-    </div> <!-- map padding -->
-  </div>
+    </div><!-- japan-map -->
+  </div><!-- map padding -->
 </div>


### PR DESCRIPTION
## 概要

- タブレットおよびスマホサイズにするとコンテンツがフッターに被ってしまう点を修正。
- PCサイズの時に画面中央に寄せられなくなっている。今回はmlで調整しているがレスポンシブでないので後日修正予定。
