### PR TITLE
Fix:地図の表示位置を修正/その他ビューを微調整#81

### DIFF
--- a/app/assets/stylesheets/search_from_japanmap.scss
+++ b/app/assets/stylesheets/search_from_japanmap.scss
@@ -63,8 +63,8 @@ a:hover {
 
 #japan-map {
 	display: block;
-	width: 777px;
-	height: 482px;
+	width: 100vh;
+	height: 100vh;
 	background-color: none;
 	margin-left: auto;
 	margin-right: auto;

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,7 +1,7 @@
 <div class="h-screen w-screen relative bg-center bg-cover bg-top-image bg-no-repeat">
   <div class="absolute w-full translate-y--2/4 translate-x--2/4">
     <p class="text-gray-700 text-base text-center px-6 bg-yellow-200 font-semibold leading-relaxed">※新型コロナウイルスの影響により工場見学を中止している醸造所がございます。</br>必ずホームページ等で最新の実施状況をご確認ください。</p> 
-    <div class="text-2xl sm:text-4xl md:text-5xl  lg:text-5xl xl:text-5xl">
+    <div class="text-3xl sm:text-4xl md:text-5xl  lg:text-5xl xl:text-5xl mt-8">
       <p class="text-orange-600 text-opacity-75 text-center py-3 px-6 font-semibold leading-relaxed">お酒が生まれる場所を訪ねよう！</p> 
       <p class="text-orange-600 text-opacity-75 text-center py-3 px-6 font-semibold leading-relaxed">お酒の工場見学検索アプリ</p> 
     </div>
@@ -10,16 +10,15 @@
   <div class="absolute mt-48 w-full translate-y--2/4 translate-x--2/4">
     <div class="h-screen w-screen flex justify-center items-center">
       <div class='search-liquor-button'>  
-          <button class=" bg-teal-500 hover:bg-teal-400 text-base sm:text-3x1 md:text-3xl lg:text-3xl xl:text-3xl text-white font-bold mr-28 py-4 px-3 rounded-full hover:shadow-sm hover:translate-y-0.5 transform transition">
-          <%= link_to "🍷 お酒から探す", search_from_liquor_type_path,class: "text-white"  %>
-          </button>
-        </div>
-        <div class='search-location-button'>
-          <button class="bg-red-500 hover:bg-red-400 text-base sm:text-3x1 md:text-3xl lg:text-3xl xl:text-3xl text-white font-bold py-4 px-3 rounded-full hover:shadow-sm hover:translate-y-0.5 transform transition">
-          <%= link_to "🗾 場所から探す", search_from_japanmap_path,class: "text-white"  %>
-          </button>
-        </div> 
+        <button class=" bg-teal-500 hover:bg-teal-400 text-base sm:text-3x1 md:text-3xl lg:text-3xl xl:text-3xl text-white font-bold mr-28 py-4 px-3 rounded-full hover:shadow-sm hover:translate-y-0.5 transform transition">
+        <%= link_to "🍷 お酒から探す", search_from_liquor_type_path,class: "text-white"  %>
+        </button>
       </div>
+      <div class='search-location-button'>
+        <button class="bg-red-500 hover:bg-red-400 text-base sm:text-3x1 md:text-3xl lg:text-3xl xl:text-3xl text-white font-bold py-4 px-3 rounded-full hover:shadow-sm hover:translate-y-0.5 transform transition">
+        <%= link_to "🗾 場所から探す", search_from_japanmap_path,class: "text-white"  %>
+        </button>
+      </div> 
     </div>
   </div>
 </div>

--- a/app/views/search_from_japanmap/index.html.erb
+++ b/app/views/search_from_japanmap/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for :title, '場所から探す' %>
 
-<div class="bg-gradient-to-r from-cyan-300 bg-cover">
-  <h1 class="flex justify-center pt-16 pl-10 text-gray-600 text-2xl sm:text-3xl md:text-3xl lg:text-4xl xl:text-4xl font-semibold">✈️ 気になる都道府県をクリック🍻✨</h1>
+<div class="h-full w-full md:h-screen bg-gradient-to-r from-cyan-300 bg-cover">
+  <h1 class="flex justify-center pt-16 pb-12 pl-10 text-gray-600 text-2xl sm:text-3xl md:text-3xl lg:text-4xl xl:text-4xl font-semibold">✈️ 気になる都道府県をクリック🍻✨</h1>
 
   <div class="pt-14">
-    <div id="japan-map" class="clearfix h-full w-full md:h-screen md:w-screen md:ml-44">
+    <div id="japan-map" class="clearfix h-full">
       <div id="hokkaido-touhoku" class="clearfix">
         <p class="area-title">北海道・東北</p>
         <div class="area">
@@ -51,7 +51,7 @@
             <%= link_to "千葉", breweries_path(q: { prefecture_eq: "千葉県" }),class: "text-white" %>
           </div>
           <div id="tokyo">
-            <%= link_to "東京", breweries_path(q: { prefecture_eq: "東京県" }),class: "text-white" %>
+            <%= link_to "東京", breweries_path(q: { prefecture_eq: "東京都" }),class: "text-white" %>
           </div>
           <div id="kanagawa">
             <%= link_to "神奈川", breweries_path(q: { prefecture_eq: "神奈川県" }),class: "text-white" %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,13 +1,14 @@
 <%= search_form_for @q, url: url do |f| %>
   <div class="p-10">
     <div class="mb-14">
-      <%= f.search_field :name_or_address_cont, class: "w-4/6 mr-8 p-4 pl-10 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500", placeholder: "キーワード検索" %>
+      <%= f.search_field :name_or_address_cont, class: "w-4/6 mr-8 p-4 pl-10 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500", placeholder: "地名／醸造所名など" %>
       
       <%= f.select :liquor_type_eq,
             Brewery.liquor_types_i18n.invert.map{|key, value| [key, Brewery.liquor_types[value]]},
             { include_blank: "お酒の種類"},
             { class: "w-52 flex-none mt-8 mr-8 p-4 pl-10 text-base bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 cursor-pointer" }
         %>
+
       <%= f.submit '検  索', class: "text-gray-700 right-2.5 bottom-2.5 bg-gradient-to-r from-lime-400 via-yellow-300 to-rose-300 hover:bg-gradient-to-bl font-bold rounded-xl border-gray-300 text-lg px-10 py-4 mt-8 cursor-pointer" %> 
     </div>
   </div>


### PR DESCRIPTION
## 概要

- 日本地図が画面サイズに応じて中央揃えになるようCSSを修正。
- 場所から検索の検索条件：東京県→東京都へ訂正。
- その他細々としたレイアウト修正。