### PR TITLE
Add:お気に入り機能の追加#100

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,11 @@
+class LikesController < ApplicationController
+  def create
+    @brewery = Brewery.find(params[:brewery_id])
+    current_user.like(@brewery)
+  end
+
+  def destroy
+    @brewery = current_user.likes.find(params[:id]).brewery
+    current_user.unlike(@brewery)
+  end
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :brewery
+
+  validates :user_id, uniqueness: { scope: :brewery_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :keeps, dependent: :destroy
   has_many :keep_breweries, through: :keeps, source: :brewery
   has_many :likes, dependent: :destroy
+  has_many :like_breweries, through: :likes, source: :brewery
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
@@ -30,5 +31,17 @@ class User < ApplicationRecord
 
   def keep?(brewery)
     keep_breweries.include?(brewery)
+  end
+
+  def like(brewery)
+    like_breweries << brewery
+  end
+
+  def unlike(brewery)
+    like_breweries.destroy(brewery)
+  end
+
+  def like?(brewery)
+    like_breweries.include?(brewery)
   end
 end

--- a/app/views/breweries/_brewery.html.erb
+++ b/app/views/breweries/_brewery.html.erb
@@ -6,10 +6,9 @@
       <%= image_tag "no_image.jpg", class: "object-cover w-full h-96 rounded-t-lg md:h-40 md:w-48 md:rounded-none md:rounded-l-lg" %>
     <% end %>
     <div class="flex flex-col justify-between p-4 leading-normal">
-        <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-700"><%= brewery.name %></h5>
-        <p class="mb-3 font-normal text-gray-700"><%= brewery.address.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')  %></p>
-        <p class="mb-3 font-normal text-gray-700">お酒の種類：<%= brewery.liquor_type_i18n %></p>
-        <%# ユーザー登録機能作成後お気に入り・気になるアイコンをつける %>
+      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-700"><%= brewery.name %></h5>
+      <p class="mb-3 font-normal text-gray-700"><%= brewery.address.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')  %></p>
+      <p class="mb-3 font-normal text-gray-700">お酒の種類：<%= brewery.liquor_type_i18n %></p>
     </div>
   </div>
 <% end %>

--- a/app/views/breweries/_like.html.erb
+++ b/app/views/breweries/_like.html.erb
@@ -1,0 +1,7 @@
+<%= link_to likes_path(brewery_id: brewery.id), id: "js-like-button-for-brewery-#{brewery.id}", method: :post, remote: true do %>
+  <button class="relative inline-flex items-center justify-center p-0.5 mb-6 mr-2 ml-4 overflow-hidden text-lg font-medium rounded-lg group bg-gradient-to-br from-pink-400 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
+    <span class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-opacity-0">
+      <p class="text-orange-400 hover:text-gray-100"><i class="mr-2 fa-regularu fa-heart"></i>お気に入りリストに登録</p>
+    </span>
+  </button>
+<% end %>

--- a/app/views/breweries/_like_button.html.erb
+++ b/app/views/breweries/_like_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.like?(brewery) %>
+  <%= render 'unlike', { brewery: brewery } %>
+<% else %>
+  <%= render 'like', { brewery: brewery }%>
+<% end %>

--- a/app/views/breweries/_unlike.html.erb
+++ b/app/views/breweries/_unlike.html.erb
@@ -1,0 +1,7 @@
+<%= link_to like_path(current_user.likes.find_by(brewery_id: brewery.id)), id: "js-like-button-for-brewery-#{brewery.id}", method: :delete, remote: true do %>
+  <button class="relative inline-flex items-center justify-center p-0.5 mb-6 mr-2 ml-4 overflow-hidden text-lg font-medium rounded-lg group bg-gradient-to-br from-pink-400 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
+    <span class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-opacity-0">
+      <p class="text-orange-400 hover:text-gray-100"><i class="mr-2 fa-solid fa-heart"></i>お気に入りリストから削除</p>
+    </span>
+  </button>
+<% end %>

--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -48,13 +48,18 @@
 
   <button class="relative inline-flex items-center justify-center p-0.5 mb-6 mr-2 ml-20 overflow-hidden text-lg font-medium rounded-lg group bg-gradient-to-br from-pink-500 to-orange-400 group-hover:from-pink-500 group-hover:to-orange-400 hover:text-white focus:outline-none focus:ring-pink-200">
     <span class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-opacity-0">
-      <%= link_to "付近の宿泊施設を探す", nearby_hotels_brewery_path, class: "text-red-400 hover:text-gray-100" %>
+      <%= link_to nearby_hotels_brewery_path, class: "text-red-400 hover:text-gray-100" do %>
+        <i class="fa-solid fa-bed"></i> 付近の宿泊施設を探す
+      <% end %>
     </span>
   </button>
 
   <% if logged_in? %>
     <div class="relative inline-flex">
       <%= render 'keep_button', { brewery: @brewery } %>
+    </div>
+    <div class="relative inline-flex ml-6">
+      <%= render 'like_button', { brewery: @brewery } %>
     </div>
   <% end %>
 

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,0 +1,1 @@
+$("#js-like-button-for-brewery-<%= @brewery.id %>").replaceWith("<%= j(render('breweries/unlike', brewery: @brewery)) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#js-like-button-for-brewery-<%= @brewery.id %>").replaceWith("<%= j(render('breweries/like', brewery: @brewery)) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,13 @@ Rails.application.routes.draw do
   resources :breweries, only: %i[index show] do
     get 'nearby_hotels', on: :member
     resources :reviews, only: %i[create update destroy], shallow: true
-    get 'keeps', on: :collection
+    collection do
+      get 'keeps'
+      get 'likes'
+    end
   end
   resources :keeps, only: %i[create destroy]
+  resources :likes, only: %i[create destroy]
   resources :users
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'

--- a/db/migrate/20230410132016_create_likes.rb
+++ b/db/migrate/20230410132016_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :brewery, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :brewery_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_07_135353) do
+ActiveRecord::Schema.define(version: 2023_04_10_132016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,16 @@ ActiveRecord::Schema.define(version: 2023_04_07_135353) do
     t.index ["user_id"], name: "index_keeps_on_user_id"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "brewery_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["brewery_id"], name: "index_likes_on_brewery_id"
+    t.index ["user_id", "brewery_id"], name: "index_likes_on_user_id_and_brewery_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "reviews", force: :cascade do |t|
     t.text "content", null: false
     t.bigint "user_id", null: false
@@ -105,6 +115,8 @@ ActiveRecord::Schema.define(version: 2023_04_07_135353) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "keeps", "breweries"
   add_foreign_key "keeps", "users"
+  add_foreign_key "likes", "breweries"
+  add_foreign_key "likes", "users"
   add_foreign_key "reviews", "breweries"
   add_foreign_key "reviews", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user { nil }
+    brewery { nil }
+  end
+end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/likes/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/likes/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
- お気に入りボタン「♡」を追加(非同期)。
- `route.rb`の`get 'keeps', on: :collection`を`get likes`も追加するためにcollectionの記述方法を変更。
- `_like`/`_unlike_button.html.erb`に条件分岐を定義>`_like`/`_unlike.html.erb`にボタンの内容を記述。
-`breweries/show.html.erb`上で条件に応じて`like`/`unlike_button.html.erb`を表示。
