### PR TITLE
Fix: ログイン・ログアウト後の画面遷移先を修正#116

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,7 +5,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to(:users, success: t('.success'))
+      redirect_back_or_to(root_path, success: t('.success'))
     else
       flash.now[:danger] = t('.fail')
       render :new
@@ -14,6 +14,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to(:users, success: t('.success'))
+    redirect_to(login_path, success: t('.success'))
   end
 end


### PR DESCRIPTION
## 概要

- ログイン後の遷移先をユーザー一覧からトップページもしくは直前のページに変更。
- ログアウト後の遷移先がユーザー一覧になっていたため、ログイン画面に修正。（修正前はバリデーションによりトップページに遷移していた。）
