### PR TITLE
Fix: 古いプロフィール画像をストレージから削除#120

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,11 @@ class UsersController < ApplicationController
   def edit; end
 
   def update
+    if params[:user][:remove_avatar] == '1'
+      @user.remove_avatar!
+      @user.save
+    end
+    
     if @user.update(user_profile_params)
       redirect_to user_path(@user), success: t('.success')
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader
+  before_save :write_avatar_identifier
+  after_commit :remove_avatar!, on: :destroy
+  after_commit :mark_remove_avatar_false, on: :update
+  after_commit :remove_previously_stored_avatar, on: :update
+  after_commit :store_avatar!, on: :update
+
   has_many :reviews, dependent: :destroy
   has_many :keeps, dependent: :destroy
   has_many :keep_breweries, through: :keeps, source: :brewery

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,8 +1,11 @@
 class AvatarUploader < CarrierWave::Uploader::Base
+  before :remove, :log_removal
+
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
   process resize_to_fit: [200, 200]
+
   # Choose what kind of storage to use for this uploader:
   # storage :file
   if Rails.env.development?
@@ -49,6 +52,12 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   # def filename
-  #   "something.jpg" if original_filename
+  #   "avatar.#{file.extension}" if original_filename
   # end
+
+  private
+
+  def log_removal
+    ::Rails.logger.info(format('Deleting file on S3: %s', @file))
+  end
 end


### PR DESCRIPTION
## 概要

- 画面上ではプロフィール画像の削除と更新ができていたが、ストレージから削除されていなかったので修正。
開発環境ではローカル、本番環境はS3へ画像が保存されるため、両方ともストレージから削除されるようにした。
1. 更新時：古い画像がストレージから削除され、新しい画像が保存される。
2. 削除時：削除した画像がストレージから削除される。画像がデフォルト画像になる。