### PR TITLE
Fix: before_login_headerのCSSを修正#125

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,23 +1,25 @@
-<nav class="bg-yellow-400 px-3.5 py-2">
+<nav class="bg-amber-400 px-3.5 py-2">
   <div class="container flex flex-wrap justify-between items-center">
     <%= link_to root_path do %>
-    <span class="font-semibold text-xl tracking-tight rounded-md hover:text-white first-line:">お酒のふるさと</span>
+      <span class="font-semibold text-xl tracking-tight rounded-md text-blue-700 hover:text-white first-line:">お酒のふるさと</span>
     <% end %>
   
-    <button data-collapse-toggle="navbar-default" type="button" class="flex-row-reverse inline-flex items-center p-2 ml-3 text-sm text-gray-100 rounded-lg md:hidden hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="navbar-default" aria-expanded="false">
-      <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path></svg>
+    <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-100 rounded-lg md:hidden hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="navbar-default" aria-expanded="false">
+      <span class="sr-only">Open main menu</span>
+      <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/>
+      </svg>
     </button>
-
     <div class="hidden w-full md:block md:w-auto" id="navbar-default">
-      <ul class="flex flex-col p-2 mt-4 rounded-lg border border-gray-100 md:flex-row md:space-x-4 md:mt-0 md:text-sm md:font-medium md:border-0">
+      <ul class="flex flex-col p-2 mt-4 rounded-lg border border-gray-100 md:flex-row md:space-x-4 md:mt-0 md:text-sm md:font-medium md:border-0 text-right">
         <li>
-          <%= link_to '醸造所検索', breweries_path, class:'block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm font-medium' %>
+          <%= link_to '醸造所検索', breweries_path, class:'inline-block text-white hover:bg-stone-500 hover:text-white px-3 py-2 rounded-md text-sm font-bold'%>
         </li>
         <li>
-          <%= link_to 'ログイン', login_path, class:'block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm font-medium' %>
+          <%= link_to 'ログイン', login_path, class:'inline-block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm font-bold' %>
         </li>
         <li>
-          <%= link_to 'ユーザー登録', new_user_path, class:'block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm font-medium' %>
+          <%= link_to 'ユーザー登録', new_user_path, class:'inline-block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm font-bold' %>
         </li>
       </ul>
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,10 @@
 <% if object.errors.any? %>
   <div id='error_messages'>
     <div class="flex p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg dark:bg-red-200 dark:text-red-800" role="alert">
-      <svg aria-hidden="true" class="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+      <svg aria-hidden="true" class="flex-shrink-0 inline w-5 h-5 mr-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
       <span class="sr-only">Danger</span>
       <div>
-        <ul class='mb-0'>
+        <ul class='mb-0 list-disc'>
         <% object.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -5,10 +5,6 @@
       <div class='ml-3 text-sm font-medium text-blue-700'>
         <%= message %>
       </div>
-      <button type="button" class='ml-auto -mx-1.5 -my-1.5 bg-blue-100 dark:bg-blue-200 text-blue-500 rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-blue-200 dark:hover:bg-blue-300 inline-flex h-8 w-8' data-dismiss-target="#alert-border-1" aria-label="Close">
-        <span class="sr-only">Dismiss</span>
-        <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
-      </button>
     </div>
   <% else %>
     <div id="alert-border-2" class="flex p-4 mb-4 bg-red-100 border-t-4 border-red-500 dark:bg-red-200" role="alert">
@@ -16,10 +12,6 @@
       <div class="ml-3 text-sm font-medium text-red-700">
         <%= message %>
       </div>
-      <button type="button" class="ml-auto -mx-1.5 -my-1.5 bg-red-100 dark:bg-red-200 text-red-500 rounded-lg focus:ring-2 focus:ring-red-400 p-1.5 hover:bg-red-200 dark:hover:bg-red-300 inline-flex h-8 w-8"  data-dismiss-target="#alert-border-2" aria-label="Close">
-      <span class="sr-only">Dismiss</span>
-      <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
-      </button>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 概要

- ログイン前のヘッダーをログイン後のヘッダーと同一に修正。
1. サービスタイトルのフォントカラーを修正。
2. ヘッダーのバックグランドカラーを修正。
3. ハンバーガーメニューのアイコンサイズを修正。
4. レスポンシブ表示を修正。（スマホサイズのメニュー名が`block`要素になっていたのを`inline-block`に修正。）
5. メニュー名のフォントサイズおよびフォントweightを修正。
6. フラッシュメッセージの「×」ボタンの動作に不具合があるため削除。

## その他
フラッシュメッセージの「×」の動作不良の原因がわからなかったので調べる。
Tailwindのコンポーネントを使用しているのでJSが読み込まれていない？
「Add: ハンバーガーメニューの作成 #108」 でflowbiteをNPM→CDNに変更する前は動いていた。