### PR TITLE
Add: お気に入り一覧の作成#119

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -46,6 +46,10 @@ class BreweriesController < ApplicationController
     @hotels = response_json
   end
 
+  def likes
+    @like_breweries = current_user.like_breweries.order(created_at: :desc).page(params[:page]).per(5)
+  end
+
   private
 
   def set_brewery

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def index
-    @user = User.all
+    @users = User.all
   end
 
   def show; end

--- a/app/views/breweries/_brewery.html.erb
+++ b/app/views/breweries/_brewery.html.erb
@@ -1,14 +1,16 @@
 <%= link_to brewery_path(brewery) do %>
-  <div class="flex flex-col items-center bg-white rounded-lg border shadow-md md:flex-row md:max-w-full mx-6 mb-6 hover:bg-gray-100">
-    <% if brewery.image %>
-      <%= image_tag "#{brewery.image}", class: "object-cover w-full h-96 rounded-t-lg md:h-40 md:w-48 md:rounded-none md:rounded-l-lg" %>
-    <% else %>
-      <%= image_tag "no_image.jpg", class: "object-cover w-full h-96 rounded-t-lg md:h-40 md:w-48 md:rounded-none md:rounded-l-lg" %>
-    <% end %>
-    <div class="flex flex-col justify-between p-4 leading-normal">
-      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-700"><%= brewery.name %></h5>
-      <p class="mb-3 font-normal text-gray-700"><%= brewery.address.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')  %></p>
-      <p class="mb-3 font-normal text-gray-700">お酒の種類：<%= brewery.liquor_type_i18n %></p>
+  <div class="flex">
+    <div class="flex w-full flex-col items-center bg-white rounded-lg border shadow-md md:flex-row md:max-w-full mx-24 md:mx-32 xl:mx-48 mb-6 hover:bg-gray-100">
+      <% if brewery.image %>
+        <%= image_tag "#{brewery.image}", class: "object-cover w-full h-60 rounded-t-lg md:h-40 md:w-48 md:rounded-none md:rounded-l-lg" %>
+      <% else %>
+        <%= image_tag "no_image.jpg", class: "object-cover w-full h-60 rounded-t-lg md:h-40 md:w-48 md:rounded-none md:rounded-l-lg" %>
+      <% end %>
+      <div class="flex flex-col justify-between p-4 leading-normal">
+        <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-700"><%= brewery.name %></h5>
+        <p class="mb-3 font-normal text-gray-700"><%= brewery.address.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')  %></p>
+        <p class="mb-3 font-normal text-gray-700">お酒の種類：<%= brewery.liquor_type_i18n %></p>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -1,12 +1,12 @@
 <% content_for :title, t('.title') %>
-<div class="bg-orange-100">
+<div class="bg-orange-100 min-h-screen">
   <%= render 'shared/search_form', url: breweries_path %>
-  <div class="mx-10">
-    <% if @breweries.present? %>
-      <%= render @breweries %>
-    <% else %>
-      <p class="text-center text-lg bg-cyan-400">⚠︎該当する醸造所が見つかりませんでした。</p> 
-    <% end %>
+  <% if @breweries.present? %>
+    <%= render @breweries %>
+  <% else %>
+    <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_result') %></p> 
+  <% end %>
+  <div class="pb-8">
     <%= paginate @breweries %>
   </div>
 </div>

--- a/app/views/breweries/likes.html.erb
+++ b/app/views/breweries/likes.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('.title') %>
+<div class="bg-rose-100 min-h-screen">
+  <div class="py-12 mb-4 text-center text-gray-600 text-2xl md:text-3xl lg:text-3xl xl:text-3xl font-bold">
+    <p><i class="mr-2 fa-solid fa-heart"></i>お気に入り一覧</p>
+  </div>
+  <% if @like_breweries.present? %>
+    <%= render partial: 'brewery', collection: @like_breweries %>
+  <% else %>
+    <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_likes') %></p> 
+  <% end %>
+  <div class="pb-8">
+    <%= paginate @like_breweries %>
+  </div>
+</div>

--- a/app/views/breweries/nearby_hotels.html.erb
+++ b/app/views/breweries/nearby_hotels.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "#{@brewery.name}付近の宿泊施設" %>
-<div class="bg-gradient-to-r from-blue-200">
+<div class="bg-gradient-to-r from-blue-200 min-h-screen">
   <div class="pt-12 text-center text-gray-700 text-base sm:text-base md:text-2xl lg:text-2xl xl:text-2xl font-bold">
   <%= @brewery.name %>　付近の宿泊施設一覧</br>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
                 <%= link_to "プロフィール", user_path(current_user), class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
               </li>
               <li>
-                <%= link_to "お気に入り一覧", "#", class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
+                <%= link_to "お気に入り一覧", likes_breweries_path, class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
               </li>
                 <li>
                 <%= link_to "気になる一覧", "#", class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,16 +28,16 @@ ja:
       create:
         success: 'ログインしました'
         fail: 'ログインに失敗しました'
-    user:
       destroy:
         success: 'ログアウトしました'
+    user:
       index:
         title: 'ユーザー一覧'
       show:
         title: 'ユーザー詳細'
       edit:
         title: 'ユーザー編集'
-      deestroy:
+      destroy:
         title: 'ユーザー削除'
     breweries:
       index:
@@ -50,6 +50,9 @@ ja:
         title: '醸造所編集'  
       destroy:
         title: '醸造所削除'  
+      likes:
+        title: 'お気に入り一覧'
+        no_likes: '⚠︎お気に入りの登録がありません。'
   users: # controllers/usersに対応
     index:
       title: 'ユーザー一覧'
@@ -78,9 +81,12 @@ ja:
   breweries:
     index:
       title: '醸造所一覧'
-      no_result: '条件に合う醸造所が見つかりません'
+      no_result: '⚠︎条件に合う醸造所が見つかりません'
     show:
       title: '醸造所詳細'
+    likes:
+      title: 'お気に入り一覧'
+      no_likes: '⚠︎お気に入りの登録がありません'
   reviews:
     create:
       success: 'レビューを投稿しました'


### PR DESCRIPTION
## 概要

- お気に入り一覧ページを作成。
1. `breweries/index`で使用した`_brewery`パーシャルを使用。
2.  ユーザー自身のみ閲覧可能。

- その他修正点
1. `breweries/index`, `nearby_hotels`で表示件数が少ない時にバックグラウンドカラーがフッター直前まで覆えていなかった点を修正。`min-h-screen`を追記。
2. `_brewery`パーシャルのレイアウトを変更。