### PR TITLE
Add: 気になる一覧の作成#128

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -50,6 +50,10 @@ class BreweriesController < ApplicationController
     @like_breweries = current_user.like_breweries.order(created_at: :desc).page(params[:page]).per(5)
   end
 
+  def keeps
+    @keep_breweries = current_user.keep_breweries.order(created_at: :desc).page(params[:page]).per(5)
+  end
+
   private
 
   def set_brewery

--- a/app/views/breweries/_keep.html.erb
+++ b/app/views/breweries/_keep.html.erb
@@ -1,7 +1,7 @@
 <%= link_to keeps_path(brewery_id: brewery.id), id: "js-keep-button-for-brewery-#{brewery.id}", method: :post, remote: true do %>
-  <button class="relative inline-flex items-center justify-center p-0.5 mb-2 mr-2 ml-4 overflow-hidden lg:text-lg md:text-base font-medium rounded-lg group bg-gradient-to-br from-yellow-400 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
+  <button class="relative inline-flex items-center justify-center p-0.5 mb-2 mr-2 ml-4 overflow-hidden lg:text-lg md:text-base font-medium rounded-lg group bg-gradient-to-br from-yellow-500 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
     <span class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-opacity-0">
-      <p class="text-yellow-400 hover:text-gray-100"><i class="mr-2 fa-regular fa-star"></i>気になるリストに登録</p>
+      <p class="text-yellow-500 hover:text-gray-100"><i class="mr-2 fa-regular fa-star"></i>気になるリストに登録</p>
     </span>
   </button>
 <% end %>

--- a/app/views/breweries/_unkeep.html.erb
+++ b/app/views/breweries/_unkeep.html.erb
@@ -1,7 +1,7 @@
 <%= link_to keep_path(current_user.keeps.find_by(brewery_id: brewery.id)), id: "js-keep-button-for-brewery-#{brewery.id}", method: :delete, remote: true do %>
-  <button class="relative inline-flex items-center justify-center p-0.5 mb-2 mr-2 ml-4 overflow-hidden lg:text-lg md:text-base font-medium rounded-lg group bg-gradient-to-br from-yellow-400 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
+  <button class="relative inline-flex items-center justify-center p-0.5 mb-2 mr-2 ml-4 overflow-hidden lg:text-lg md:text-base font-medium rounded-lg group bg-gradient-to-br from-yellow-500 to-orange-500 group-hover:from-yellow-400 group-hover:to-orange-500 hover:text-white focus:outline-none focus:ring-yellow-200">
     <span class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-opacity-0">
-      <p class="text-yellow-400 hover:text-gray-100"><i class="mr-2 fa-solid fa-star"></i>気になるリストから削除</p>
+      <p class="text-yellow-500 hover:text-gray-100"><i class="mr-2 fa-solid fa-star"></i>気になるリストから削除</p>
     </span>
   </button>
 <% end %>

--- a/app/views/breweries/keeps.html.erb
+++ b/app/views/breweries/keeps.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('.title') %>
+<div class="bg-yellow-100 min-h-screen">
+  <div class="py-12 mb-4 text-center text-gray-600 text-2xl md:text-3xl lg:text-3xl xl:text-3xl font-bold">
+    <i class="mr-2 fa-solid fa-star"></i><%= t('.title') %>
+  </div>
+  <% if @keep_breweries.present? %>
+    <%= render partial: 'brewery', collection: @keep_breweries %>
+  <% else %>
+    <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_keeps') %></p> 
+  <% end %>
+  <div class="pb-8 text-gray-500 font-bold">
+    <%= paginate @keep_breweries %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,7 +28,7 @@
                 <%= link_to "お気に入り一覧", likes_breweries_path, class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
               </li>
                 <li>
-                <%= link_to "気になる一覧", "#", class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
+                <%= link_to "気になる一覧", keeps_breweries_path, class:"block text-white hover:bg-stone-500  hover:text-white px-3 py-2 rounded-md text-sm" %>
               </li>
             </ul>
           </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,6 +87,9 @@ ja:
     likes:
       title: 'お気に入り一覧'
       no_likes: '⚠︎お気に入りの登録がありません'
+    keeps:
+      title: '気になる一覧'
+      no_keeps: '⚠︎気になるの登録がありません'
   reviews:
     create:
       success: 'レビューを投稿しました'


### PR DESCRIPTION
## 概要

- お気に入り一覧ページを作成。
1. breweries/indexで使用した_breweryパーシャルを使用。
2. ユーザー自身のみ閲覧可能。

- その他修正点
1. breweries/showページの「気になる」ボタンが見づらいためカラーを変更。
