### PR TITLE
Fix: 不要なgemの削除とリント修正#133

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem 'font-awesome-sass', '~> 5.15.1'
 gem 'sassc', '2.1.0'
 
 # Authentication
-gem 'pundit'
 gem 'sorcery'
 
 # UI/UX

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    cancancan (3.5.0)
     capybara (3.37.1)
       addressable
       matrix
@@ -283,6 +284,7 @@ GEM
     msgpack (1.5.6)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    nested_form (0.3.2)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -324,8 +326,6 @@ GEM
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
-    pundit (2.2.0)
-      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-mini-profiler (2.3.4)
@@ -357,6 +357,12 @@ GEM
     rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_admin (3.1.2)
+      activemodel-serializers-xml (>= 1.0)
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rails (>= 6.0, < 8)
+      turbo-rails (~> 1.0)
     rails_best_practices (1.23.1)
       activesupport
       code_analyzer (~> 0.5.5)
@@ -495,6 +501,10 @@ GEM
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
+    turbo-rails (1.4.0)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
@@ -537,6 +547,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   bullet
   byebug
+  cancancan
   capybara
   carrierwave (~> 3.0)
   carrierwave-i18n
@@ -564,10 +575,10 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)
-  pundit
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
   rails-i18n
+  rails_admin (~> 3.0)
   rails_best_practices
   ransack
   rspec-rails

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -13,10 +13,10 @@ class PasswordResetsController < ApplicationController
     @token = params[:id]
     @user = User.load_from_reset_password_token(params[:id])
 
-    if @user.blank?
-      not_authenticated
-      nil
-    end
+    return unless @user.blank?
+
+    not_authenticated
+    nil
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
       @user.remove_avatar!
       @user.save
     end
-    
+
     if @user.update(user_profile_params)
       redirect_to user_path(@user), success: t('.success')
     else

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -7,7 +7,7 @@
       </div>
     </div>
   <% else %>
-    <div id="alert-border-2" class="flex p-4 mb-4 bg-red-100 border-t-4 border-red-500 dark:bg-red-200" role="alert">
+    <div id="alert-border-2" class="flex p-4 bg-red-100 border-t-4 border-red-500 dark:bg-red-200" role="alert">
       <svg class="flex-shrink-0 w-5 h-5 text-red-700" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
       <div class="ml-3 text-sm font-medium text-red-700">
         <%= message %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -21,7 +21,7 @@ ja:
       brewery: '醸造所'
       review: 'レビュー'
       like: 'お気に入り'
-      keep: '興味あり'
+      keep: '気になる'
     attributes:
       # view→t(User.human_attribute_name :name) => "名前" / t("activerecord.attributes.user.name")
       user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
-  root  to: 'home#top'
+  root to: 'home#top'
   resources :breweries, only: %i[index show] do
     get 'nearby_hotels', on: :member
     resources :reviews, only: %i[create update destroy], shallow: true


### PR DESCRIPTION
## 概要

- `gem pundit`を削除。実装予定の`admin-rails`で推奨されている`CanCanCan`を使用する。
- リント修正
- フラッシュメッセージのCSS修正。successとdangerの CSSが一致していなかったため修正。
