### PR TITLE
Add: 管理画面の作成#122

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
   Max: 35
 
 Metrics/BlockLength:
-  Max: 30
+  Max: 50
   Exclude:
     - 'Gemfile'
     - 'config/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'sassc', '2.1.0'
 # Authentication
 gem 'sorcery'
 
+# Authorization
+gem 'cancancan'
+
 # UI/UX
 gem 'rails-i18n'
 
@@ -70,6 +73,9 @@ gem 'kaminari-i18n'
 
 # Seeds
 gem 'seed-fu'
+
+# admin
+gem 'activeadmin'
 
 group :development, :test do
   # Debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,15 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activeadmin (2.14.0)
+      arbre (~> 1.2, >= 1.2.1)
+      formtastic (>= 3.1, < 5.0)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.2.1)
+      railties (>= 6.1, < 7.1)
+      ransack (>= 2.1.1, < 4)
     activejob (6.1.6.1)
       activesupport (= 6.1.6.1)
       globalid (>= 0.3.6)
@@ -69,6 +78,9 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
+    arbre (1.6.0)
+      activesupport (>= 3.0.0, < 7.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.626.0)
@@ -209,6 +221,9 @@ GEM
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
     formatador (1.1.0)
+    formtastic (4.0.0)
+      actionpack (>= 5.2.0)
+    formtastic_i18n (0.7.0)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -221,17 +236,29 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
+    has_scope (0.8.1)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    inherited_resources (1.13.1)
+      actionpack (>= 5.2, < 7.1)
+      has_scope (~> 0.6)
+      railties (>= 5.2, < 7.1)
+      responders (>= 2, < 4)
     jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
+    jquery-rails (4.6.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.6.2)
     jwt (2.5.0)
     kaminari (1.2.2)
@@ -284,7 +311,6 @@ GEM
     msgpack (1.5.6)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    nested_form (0.3.2)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -357,12 +383,6 @@ GEM
     rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_admin (3.1.2)
-      activemodel-serializers-xml (>= 1.0)
-      kaminari (>= 0.14, < 2.0)
-      nested_form (~> 0.3)
-      rails (>= 6.0, < 8)
-      turbo-rails (~> 1.0)
     rails_best_practices (1.23.1)
       activesupport
       code_analyzer (~> 0.5.5)
@@ -390,6 +410,9 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     require_all (3.0.0)
+    responders (3.1.0)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -501,10 +524,6 @@ GEM
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
-    turbo-rails (1.4.0)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
@@ -540,6 +559,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activeadmin
   annotate
   aws-sdk-s3
   better_errors
@@ -578,7 +598,6 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
   rails-i18n
-  rails_admin (~> 3.0)
   rails_best_practices
   ransack
   rspec-rails

--- a/app/admin/breweries.rb
+++ b/app/admin/breweries.rb
@@ -1,0 +1,16 @@
+ActiveAdmin.register Brewery do
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :name, :address, :phone_number, :prefecture, :liquor_type, :website_url, :photo_reference, :video_id, :latitude, :longitude, :place_id, :image
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:name, :address, :phone_number, :prefecture, :liquor_type, :website_url, :photo_reference, :video_id, :latitude, :longitude, :place_id, :image]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register_page 'Dashboard' do
+  menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
+
+  content title: proc { I18n.t('active_admin.dashboard') } do
+    div class: 'blank_slate_container', id: 'dashboard_default_message' do
+      span class: 'blank_slate' do
+        span I18n.t('active_admin.dashboard_welcome.welcome')
+        small I18n.t('active_admin.dashboard_welcome.call_to_action')
+      end
+    end
+
+    # Here is an example of a simple dashboard with columns and panels.
+    #
+    # columns do
+    #   column do
+    #     panel "Recent Posts" do
+    #       ul do
+    #         Post.recent(5).map do |post|
+    #           li link_to(post.title, admin_post_path(post))
+    #         end
+    #       end
+    #     end
+    #   end
+
+    #   column do
+    #     panel "Info" do
+    #       para "Welcome to ActiveAdmin."
+    #     end
+    #   end
+    # end
+  end
+end

--- a/app/admin/keeps.rb
+++ b/app/admin/keeps.rb
@@ -1,0 +1,21 @@
+ActiveAdmin.register Keep do
+  controller do
+    def scoped_collection
+      super.eager_load(:user, :brewery)
+    end
+  end
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :brewery_id, :user_id
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:brewery_id, :user_id]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+end

--- a/app/admin/likes.rb
+++ b/app/admin/likes.rb
@@ -1,0 +1,22 @@
+ActiveAdmin.register Like do
+  controller do
+    def scoped_collection
+      super.eager_load(:user, :brewery)
+    end
+  end
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :brewery_id, :user_id
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:brewery_id, :user_id]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+end

--- a/app/admin/reviews.rb
+++ b/app/admin/reviews.rb
@@ -1,0 +1,21 @@
+ActiveAdmin.register Review do
+  controller do
+    def scoped_collection
+      super.eager_load(:user, :brewery)
+    end
+  end
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :content, :brewery_id, :user_id
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:content, :brewery_id, :user_id]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,0 +1,54 @@
+ActiveAdmin.register User do
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :email, :crypted_password, :salt, :name, :avatar, :remove_avatar, :living_place, :favorite_liquor_type, :self_introduction, :role, :reset_password_token, :reset_password_token_expires_at, :reset_password_email_sent_at, :access_count_to_reset_password_page
+  #
+  # or
+  permit_params do
+    permitted = %i[email name avatar avatar_cache remove_avatar living_place favorite_liquor_type self_introduction role]
+    permitted << :other if params[:action] == 'create' && current_user.admin?
+    permitted
+  end
+
+  # Customize form for delete avatar
+  form do |f|
+    f.inputs 'Users' do
+      f.input :name
+      f.input :email
+      f.input :avatar, as: :file, hint: f.object.avatar.present? ? image_tag(f.object.avatar.url) : nil
+      if f.object.avatar.present?
+        f.input :remove_avatar, as: :boolean, required: false, label: '画像を削除する'
+      end
+      f.input :living_place
+      f.input :favorite_liquor_type
+      f.input :self_introduction
+      f.input :role
+    end
+    f.actions
+  end
+
+  # Customize show for showing avatar image
+  show do |_item_image|
+    attributes_table do
+      row :id
+      row :name
+      row :email
+      row :avatar do
+        image_tag(user.avatar.url, style: 'max-width: 200px;')
+      end
+      row :living_place
+      row :favorite_liquor_type
+      row :self_introduction
+      row :role
+      row :reset_password_token
+      row :crypted_password
+      row :salt
+      row :reset_password_token_expires_at
+      row :reset_password_email_sent_at
+      row :access_count_to_reset_password_page
+    end
+  end
+end

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,0 +1,1 @@
+//= require active_admin/base

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -1,0 +1,17 @@
+// Sass variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "active_admin/mixins";
+@import "active_admin/base";
+
+// Overriding any non-variable Sass must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_action :require_login
   add_flash_types :success
+
+  def not_authenticated
+    redirect_to login_path, alert: 'ログインしてください'
+  end
+
+  def access_denied(_exception)
+    redirect_to root_path, alert: '管理者専用ページです'
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the user here. For example:
+    #
+    #   return unless user.present?
+    #   can :read, :all
+    return unless user.admin?
+
+    can :manage, :all # 許可内容
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,355 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = 'お酒のふるさと'
+  config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Load Paths
+  #
+  # By default Active Admin files go inside app/admin/.
+  # You can change this directory.
+  #
+  # eg:
+  #   config.load_paths = [File.join(Rails.root, 'app', 'ui')]
+  #
+  # Or, you can also load more directories.
+  # Useful when setting namespaces with users that are not your main AdminUser entity.
+  #
+  # eg:
+  #   config.load_paths = [
+  #     File.join(Rails.root, 'app', 'admin'),
+  #     File.join(Rails.root, 'app', 'cashier')
+  #   ]
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  # config.authentication_method = :authenticate_user!
+  config.authentication_method = :require_login
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # If you wish to maintain a separate set of Pundit policies for admin
+  # resources, you may set a namespace here that Pundit will search
+  # within when looking for a resource's policy.
+  # config.pundit_policy_namespace = :admin
+
+  # You can customize your CanCan Ability class name here.
+  config.cancan_ability_class = 'Ability'
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+  config.current_user_method = :current_user
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  # config.logout_link_path = :destroy_user_session_path
+  config.logout_link_path = :logout_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  # config.logout_link_method = :get
+  config.logout_link_method = :delete
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  # config.root_to = 'dashboard#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  # config.comments = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+  #
+  # You can change the order for the comments and you can change the column
+  # to be used for ordering:
+  # config.comments_order = 'created_at ASC'
+  #
+  # You can disable the menu item for the comments index page:
+  config.comments_menu = false
+  #
+  # You can customize the comment menu:
+  # config.comments_menu = { parent: 'Admin', priority: 1 }
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_action :do_something_awesome
+
+  # == Attribute Filters
+  #
+  # You can exclude possibly sensitive model attributes from being displayed,
+  # added to forms, or exported by default by ActiveAdmin
+  #
+  config.filter_attributes = %i[encrypted_password password password_confirmation]
+
+  # == Localize Date/Time Format
+  #
+  # Set the localize format to display dates and times.
+  # To understand how to localize your app with I18n, read more at
+  # https://guides.rubyonrails.org/i18n.html
+  #
+  # You can run `bin/rails runner 'puts I18n.t("date.formats")'` to see the
+  # available formats in your application.
+  #
+  config.localize_format = :long
+
+  # == Setting a Favicon
+  #
+  # config.favicon = 'favicon.ico'
+
+  # == Meta Tags
+  #
+  # Add additional meta tags to the head element of active admin pages.
+  #
+  # Add tags to all pages logged in users see:
+  #   config.meta_tags = { author: 'My Company' }
+
+  # By default, sign up/sign in/recover password pages are excluded
+  # from showing up in search engine results by adding a robots meta
+  # tag. You can reset the hash of meta tags included in logged out
+  # pages:
+  #   config.meta_tags_for_logged_out_pages = {}
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Create Another Checkbox
+  #
+  # Create another checkbox is disabled by default. You can customize it for individual
+  # resources or you can enable them globally from here.
+  #
+  # config.create_another = true
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :utility_navigation do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #       admin.add_logout_button_to_menu menu
+  #     end
+  #   end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+  #
+  # You can control the max per page count too.
+  #
+  # config.max_per_page = 10_000
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+  #
+  # By default the filters include associations in a select, which means
+  # that every record will be loaded for each association (up
+  # to the value of config.maximum_association_filter_arity).
+  # You can enabled or disable the inclusion
+  # of those filters by default here.
+  #
+  # config.include_default_association_filters = true
+
+  # config.maximum_association_filter_arity = 256 # default value of :unlimited will change to 256 in a future version
+  # config.filter_columns_for_large_association = [
+  #    :display_name,
+  #    :full_name,
+  #    :name,
+  #    :username,
+  #    :login,
+  #    :title,
+  #    :email,
+  #  ]
+  # config.filter_method_for_large_association = '_starts_with'
+
+  # == Head
+  #
+  # You can add your own content to the site head like analytics. Make sure
+  # you only pass content you trust.
+  #
+  # config.head = ''.html_safe
+
+  # == Footer
+  #
+  # By default, the footer shows the current Active Admin version. You can
+  # override the content of the footer here.
+  #
+  # config.footer = 'my custom footer text'
+
+  # == Sorting
+  #
+  # By default ActiveAdmin::OrderClause is used for sorting logic
+  # You can inherit it with own class and inject it for all resources
+  #
+  # config.order_clause = MyOrderClause
+
+  # == Webpacker
+  #
+  # By default, Active Admin uses Sprocket's asset pipeline.
+  # You can switch to using Webpacker here.
+  #
+  # config.use_webpacker = true
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,38 +21,6 @@ ja:
       delete_confirm: '削除しますか？'
       not_authenticated: 'ログインしてください'
       not_authorized: '権限がありません'
-  admin: # controllers/adminに対応
-    user_sessions:
-      new:
-        title: 'ログイン'
-      create:
-        success: 'ログインしました'
-        fail: 'ログインに失敗しました'
-      destroy:
-        success: 'ログアウトしました'
-    user:
-      index:
-        title: 'ユーザー一覧'
-      show:
-        title: 'ユーザー詳細'
-      edit:
-        title: 'ユーザー編集'
-      destroy:
-        title: 'ユーザー削除'
-    breweries:
-      index:
-        title: '醸造所一覧'
-      new:
-        title: '醸造所作成'
-      show:
-        title: '醸造所詳細'
-      edit:
-        title: '醸造所編集'  
-      destroy:
-        title: '醸造所削除'  
-      likes:
-        title: 'お気に入り一覧'
-        no_likes: '⚠︎お気に入りの登録がありません。'
   users: # controllers/usersに対応
     index:
       title: 'ユーザー一覧'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  ActiveAdmin.routes(self)
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   root to: 'home#top'
   resources :breweries, only: %i[index show] do

--- a/db/migrate/20230820161358_create_active_admin_comments.rb
+++ b/db/migrate/20230820161358_create_active_admin_comments.rb
@@ -1,0 +1,16 @@
+class CreateActiveAdminComments < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/migrate/20230822163607_drop_active_admin_comments.rb
+++ b/db/migrate/20230822163607_drop_active_admin_comments.rb
@@ -1,0 +1,11 @@
+class DropActiveAdminComments < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_02_133723) do
+ActiveRecord::Schema.define(version: 2023_08_22_163607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6054,9 +6054,9 @@
     "source-map" "^0.6.1"
 
 "postcss@^8.0.0", "postcss@^8.0.9", "postcss@^8.1.0", "postcss@^8.2.14", "postcss@^8.4.21", "postcss@>=8.0.9":
-  "integrity" "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ=="
-  "resolved" "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz"
-  "version" "8.4.27"
+  "integrity" "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw=="
+  "resolved" "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz"
+  "version" "8.4.28"
   dependencies:
     "nanoid" "^3.3.6"
     "picocolors" "^1.0.0"


### PR DESCRIPTION
## 概要

- `ActiveAdmin`で管理画面を作成。

- カスタマイズ性や編集の容易さ考慮して`Rails-Admin`ではなく`ActiveAdmin`使用に変更。

- 管理画面上で`bullet`のアラートが出るためadminモデルファイルに`eager_load`を記述。

- `Rubocop`で`Metrics/BlockLength`が長いと指摘されてしまうのでMax値を変更。