### PR TITLE
Modify: nearby_hotelsをbreweriesから切り出し#137

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -14,38 +14,6 @@ class BreweriesController < ApplicationController
     @reviews = @brewery.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(5)
   end
 
-  def nearby_hotels
-    require 'uri'
-    require 'net/http'
-    require 'openssl'
-
-    @brewery = Brewery.find(params[:id])
-    api_key = Rails.application.credentials.rapid_booking[:api_key]
-    checkin_date = Date.today.next_month
-    checkout_date = checkin_date + 1
-
-    query = URI.encode_www_form(
-      checkin_date: checkin_date,
-      checkout_date: checkout_date,
-      longitude: @brewery.longitude,
-      latitude: @brewery.latitude
-    )
-
-    url = URI("https://booking-com.p.rapidapi.com/v1/hotels/search-by-coordinates?order_by=distance&adults_number=1&units=metric&room_number=1&filter_by_currency=JPY&locale=ja&page_number=0&include_adjacency=true&#{query}")
-
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-    request = Net::HTTP::Get.new(url)
-    request['X-RapidAPI-Key'] = api_key
-    request['X-RapidAPI-Host'] = 'booking-com.p.rapidapi.com'
-    response = http.request(request)
-    response_json = JSON.parse(response.body)
-
-    @hotels = response_json
-  end
-
   def likes
     @like_breweries = current_user.like_breweries.order(created_at: :desc).page(params[:page]).per(5)
   end

--- a/app/controllers/nearby_hotels_controller.rb
+++ b/app/controllers/nearby_hotels_controller.rb
@@ -1,0 +1,9 @@
+class NearbyHotelsController < ApplicationController
+  def index
+    @brewery = Brewery.find(params[:id])
+    hotels_search_service = HotelsSearchService.new(@brewery)
+    @hotels = hotels_search_service.nearby_hotels
+
+    render 'breweries/nearby_hotels'
+  end
+end

--- a/app/decorators/nearby_hotel_decorator.rb
+++ b/app/decorators/nearby_hotel_decorator.rb
@@ -1,0 +1,12 @@
+class NearbyHotelDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/helpers/nearby_hotels_helper.rb
+++ b/app/helpers/nearby_hotels_helper.rb
@@ -1,0 +1,2 @@
+module NearbyHotelsHelper
+end

--- a/app/services/hotels_search_service.rb
+++ b/app/services/hotels_search_service.rb
@@ -1,0 +1,44 @@
+class HotelsSearchService
+  def initialize(brewery)
+    @brewery = brewery
+  end
+
+  def nearby_hotels
+    make_api_response
+  end
+
+  private
+
+  def make_api_request
+    require 'uri'
+    require 'net/http'
+    require 'openssl'
+
+    api_key = Rails.application.credentials.rapid_booking[:api_key]
+    checkin_date = Date.today.next_month
+    checkout_date = checkin_date + 1
+
+    query = URI.encode_www_form(
+      checkin_date: checkin_date,
+      checkout_date: checkout_date,
+      longitude: @brewery.longitude,
+      latitude: @brewery.latitude
+    )
+
+    url = URI("https://booking-com.p.rapidapi.com/v1/hotels/search-by-coordinates?order_by=distance&adults_number=1&units=metric&room_number=1&filter_by_currency=JPY&locale=ja&page_number=0&include_adjacency=true&#{query}")
+
+    @http = Net::HTTP.new(url.host, url.port)
+    @http.use_ssl = true
+    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    @request = Net::HTTP::Get.new(url)
+    @request['X-RapidAPI-Key'] = api_key
+    @request['X-RapidAPI-Host'] = 'booking-com.p.rapidapi.com'
+  end
+
+  def make_api_response
+    make_api_request # @http,@requestインスタンス作成。
+    response = @http.request(@request)
+    JSON.parse(response.body)
+  end
+end

--- a/app/views/breweries/nearby_hotels.html.erb
+++ b/app/views/breweries/nearby_hotels.html.erb
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-12 mt-10 mx-10 pb-10">
       <% if @hotels["result"].present? %>
-        <%= render 'nearby_hotel', { brewery: @brewery, url: nearby_hotels_brewery_path(@brewery) } %>
+        <%= render 'breweries/nearby_hotel', { brewery: @brewery, url: nearby_hotels_brewery_path(@brewery) } %>
       <% else %>
         <p class="text-center text-lg bg-cyan-400">⚠︎該当する宿泊施設が見つかりませんでした。</p>       
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   root to: 'home#top'
   resources :breweries, only: %i[index show] do
-    get 'nearby_hotels', on: :member
+    get 'nearby_hotels', on: :member, to: 'nearby_hotels#index'
     resources :reviews, only: %i[create update destroy], shallow: true
     collection do
       get 'keeps'

--- a/spec/requests/nearby_hotels_spec.rb
+++ b/spec/requests/nearby_hotels_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "NearbyHotels", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要

- サービスクラス`hotels_search_sevice.rb`を作成。API処理の部分を`breweries#nearby_hotels`から移動。
- `nearby_hotels`コントローラを作成。サービスクラスを呼び出して表示部分を記述。
- `nearby_hotels`コントローラの`index`アクションに飛ぶよう`routing`に`to: 'nearby_hotels#index'`オプションを追加。


