### PR TITLE
Add: レビューにリンクを追加#141

### DIFF
--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,7 +1,10 @@
 <tr id="review-<%= review.id %>">
   <td class="text-gray-600 pb-4">
     <div class="flex flex-wrap mt-1 mb-1">
-      <h2 class="mr-4 font-bold">🍷<%= review.user.name %>さん</h2>
+      <%= image_tag review.user.avatar.url, size: '30x30', class: "bg-white" %>
+      <%= link_to user_path(review.user) do %>
+        <h2 class="mr-4 ml-1 font-bold text-blue-700">🍷<%= review.user.name %>さん</h2>
+      <% end %>
       <span><%= l review.created_at, format: :short %></span>
     </div>
     <div id="js-review-<%= review.id %>" class="ml-3">

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -9,7 +9,7 @@
         { class: "w-52 flex-none mt-8 mr-8 p-4 pl-10 text-base bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 cursor-pointer" }
       %>
 
-      <%= f.select :address_cont,
+      <%= f.select :prefecture_eq,
         Brewery.prefecture_enums.keys,{ include_blank: "都道府県"},
         { class: "w-52 flex-none mt-8 mr-8 p-4 pl-10 text-base bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 cursor-pointer" }
       %> 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "#{@user.name}さんのプロフィール" %>
 <div class="bg-lime-100 min-h-screen">
-<div class="flex md:flex-row md:max-w-full mx-10 pt-12 mb-4 md:mx-60">
-  <%= image_tag "#{@user.avatar}", size: "200x200", class: "rounded-md" %>
+<div class="flex md:flex-row md:max-w-full items-center justify-center pt-12 mx-10">
+  <%= image_tag "#{@user.avatar}", size: "200x200", class: "rounded-md bg-white" %>
 </div>
 <div class="overflow-x-auto relative shadow-xl rounded-lg mx-10 mt-8 ms:mx-60 md:mx-60">
   <table class="w-full text-lg text-gray-600">
@@ -31,7 +31,7 @@
 </div>
 <% if current_user == @user %>
   <div class="flex">
-    <div class="relative inline-flex my-4 ml-16 md:mx-60 text-normal font-bold text-blue-700">
+    <div class="relative inline-flex my-4 ml-16 md:mx-60 text-base font-bold text-blue-700">
       <%= link_to "プロフィールを編集", edit_user_path %>
     </div>
   </div>


### PR DESCRIPTION
## 概要

- レビューのユーザー名にプロフィールへのリンクを追加。
- レビューのユーザー名の横に`avatar`を追加。
- #140 で追加した「都道府県から検索」フォーム(shared/_search_form)を修正。
`:address_cont`→`:prefecture_eq`
`:address_cont`だと京都府の検索結果に東京都府中市のbreweryが引っかかってしまう。
- users/showページの`avatar`表示位置を変更。