### PR TITLE
Add: ユーザー一覧画面の作成#143

### DIFF
--- a/app/controllers/nearby_hotels_controller.rb
+++ b/app/controllers/nearby_hotels_controller.rb
@@ -1,4 +1,6 @@
 class NearbyHotelsController < ApplicationController
+  skip_before_action :require_login
+
   def index
     @brewery = Brewery.find(params[:id])
     hotels_search_service = HotelsSearchService.new(@brewery)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def index
-    @users = User.all
+    @users = User.all.order(id: :asc).page(params[:page]).per(12)
   end
 
   def show; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_breweries, through: :likes, source: :brewery
 
-  validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 20 }
   validates :email, presence: true, uniqueness: true
   validates :self_introduction, length: { maximum: 300 }
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,8 @@
+<%= link_to user_path(user) do %>
+  <div class="flex flex-col items-center py-5 px-5">
+    <% if user.avatar %>
+      <%= image_tag "#{user.avatar}", class: "object-cover w-20 h-20 rounded-full bg-white md:w-40 md:h-40 md:rounded-full" %>
+    <% end %>
+    <h5 class="mb-1 text-base md:text-lg font-medium text-blue-700"><%= user.name %></h5>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,20 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
+<% content_for :title, t('.title') %>
+<div class="bg-orange-100 min-h-screen">
+  <div class="w-full text-center">
+    <div class="py-12 mb-4 text-center text-gray-600 text-2xl md:text-3xl lg:text-3xl xl:text-3xl font-bold">ユーザー一覧</div>
+    <% if @users.present? %>
+      <div class="flex w-full justify-center">
+        <div class="flex flex-wrap items-center justify-center w-full px-4"> 
+          <div class="grid grid-cols-3 gap-3 md:grid-cols-4">
+          <%= render @users %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_reslt') %></p> 
+    <% end %>
+    <div class="py-10 text-gray-500 font-bold">
+      <%= paginate @users, window:2 %>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require 'action_text/engine'
 require 'action_view/railtie'
 require 'action_cable/engine'
 require 'sprockets/railtie'
+require 'faker'
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -24,7 +25,7 @@ module OsakeNoFurusato
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     # アプリケーションが対応している言語のホワイトリスト
-    config.i18n.available_locales = %i[ja]
+    config.i18n.available_locales = %i[ja en]
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
@@ -38,5 +39,6 @@ module OsakeNoFurusato
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    Faker::Config.locale
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,6 +24,7 @@ ja:
   users: # controllers/usersに対応
     index:
       title: 'ユーザー一覧'
+      no_result: 登録ユーザーが存在しません''
     new: # users/newアクションに対応
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+
+20.times do |n|
+  name = "user0#{n}"
+  email = Faker::Internet.email
+  password = 'fakerpassword0'
+  password_confirmation = 'fakerpassword0'
+  living_place = Faker::Address.state
+  favorite_liquor_type = 0
+  self_introduction = Faker::JapaneseMedia::StudioGhibli.quote 
+  role = 0
+  User.create!(name: name, email: email, password: password, password_confirmation: password_confirmation, role: role, living_place: living_place, favorite_liquor_type: favorite_liquor_type, self_introduction: self_introduction)
+end


### PR DESCRIPTION
## 概要

- ユーザー一覧画面を作成。
- 一覧画面のレイアウト崩れ防止のためユーザー名のバリデーションを255文字から20文字に変更。
- `gem faker`を使用して`seeds`でローカルユーザーを作成。
- `gem faker`を日本語で使用するため`config.application.rb`を修正。
- 3fafcfc にて漏れていた`skip_before_action :require_login`を`NearbyHotelsController`へ追記。未ログイン状態でもホテル検索が使用できるように修正。

## 確認方法

行った修正をレビュアーが確認するための手順を記載する。
例：
1. `seeds`ファイルを作成しましたので、`rails db:seed`でユーザーデータの作成をお願い致します。
2. `/users`ページにアクセスしてユーザー一覧の表示をご確認願います。
3. ユーザー一覧より各ユーザーのプロフィールへ飛んでください。
4. ユーザープロフィールより次の4点が表示されていることをご確認ください。
　・ユーザー名/居住地/好きなお酒/自己紹介

## チェックリスト
- [x] rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認 

## その他
プロフィールページのレイアウトが気になります。テーブルの幅が画面サイズにより大きすぎたり狭すぎたりとアンバランスに感じるので修正を検討しています。