### PR TITLE
Fix: gemfileを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'kaminari-i18n'
 
 # Seeds
 gem 'seed-fu'
+gem 'faker'
 
 # admin
 gem 'activeadmin'
@@ -120,7 +121,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'faker'
   gem 'fuubar'
   gem 'simplecov', require: false
   gem 'webdrivers'


### PR DESCRIPTION
## 概要

herokuへのデプロイで下記のエラーが発生したためGemfileを修正。
```
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     LoadError: cannot load such file -- faker
```
`gem faker`を`test`環境のグループに入れてしまっていた点を修正。