### PR TITLE
Fix: プロフィールのレイアウトを修正#144

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,38 +1,43 @@
 <%= javascript_pack_tag 'preview_image' %>
 <% content_for :title, t('.title')%>
-<div class= 'flex flex-col items-center text-neutral-500 text-lg'>
+<div class= 'flex flex-col items-center'>
   <div class='w-full max-w-md'>
-    <div class='text-center my-8'>
+    <div class='text-center my-8 text-neutral-500 text-lg'>
       <h1><%= t('.title') %></h1>
     </div>
     <%= form_with model: @user, url: user_path, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
-      <div class="mx-8 text-gray-700 text-sm font-bold">      
+      <div class="mx-8">
         <%= image_tag @user.avatar.url, id: "preview", size: "200x200", accept: "image/*", class: "inline mx-20 mb-4 rounded-md" %></br>
-        <div class='mb-2 font-bold'>
+      </div>
+      <div class="mx-8 mb-6 text-gray-700 text-sm font-bold">
+        <%= User.human_attribute_name(:name) %>：<%= @user.name %>
+      </div>
+      <div class="mx-8 text-gray-700 text-sm font-bold">
+        <div class='mb-2'>
           <%= f.label :avatar %>
+          <% if @user.avatar? %>
+            <label class="ml-4">
+              <%= f.check_box :remove_avatar %>
+              <%= t('.delete') %>
+            </label>
+          <% end %>
         </div>
-        <%= f.file_field :avatar, onchange: "previewImage()", class: "block w-full mb-2 text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none" %>
+        <%= f.file_field :avatar, onchange: "previewImage()", class: "block w-full mb-2 text-sm border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none" %>
         <%= f.hidden_field :avatar_cache %>
-        <% if @user.avatar? %>
-          <label>
-            <%= f.check_box :remove_avatar %>
-            画像を削除する
-          </label>
-        <% end %>
       </div>
       <div class='flex flex-col justify-center flex-wrap mb-6 mx-8'>
-        <div class='text-gray-700 text-sm mt-6 mb-8'>
-          <div class='mb-2 font-bold'>
+        <div class='text-gray-700 text-sm mt-6 mb-8 font-bold'>
+          <div class='mb-2'>
             <%= f.label :living_place, User.human_attribute_name(:living_place) %>
           </div>
-          <%= f.select :living_place, User.prefecture_enums, { include_blank: "未設定", selected: @user.living_place }, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+          <%= f.select :living_place, User.prefecture_enums, { include_blank: t('.not_selected'), selected: @user.living_place }, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
         </div>
-        <div class='text-gray-700 text-sm mb-8'>
-          <div class='mb-2 font-bold'>
+        <div class='text-gray-700 text-sm mb-8 font-bold'>
+          <div class='mb-2'>
             <%= f.label :favorite_liquor_type, User.human_attribute_name(:favorite_liquor_type) %>
           </div>
-          <%= f.select :favorite_liquor_type, User.favorite_liquor_types.keys.map { |k| [I18n.t("enums.user.favorite_liquor_type.#{k}"), k] }, { include_blank: "未設定", selected: @user.favorite_liquor_type }, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+          <%= f.select :favorite_liquor_type, User.favorite_liquor_types.keys.map { |k| [I18n.t("enums.user.favorite_liquor_type.#{k}"), k] }, { include_blank: t('.not_selected'), selected: @user.favorite_liquor_type }, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
         </div>
         <div class='text-gray-700 text-sm mb-8'>
           <div class='mb-2 font-bold'>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,39 +1,39 @@
 <% content_for :title, "#{@user.name}さんのプロフィール" %>
 <div class="bg-lime-100 min-h-screen">
-<div class="flex md:flex-row md:max-w-full items-center justify-center pt-12 mx-10">
-  <%= image_tag "#{@user.avatar}", size: "200x200", class: "rounded-md bg-white" %>
-</div>
-<div class="overflow-x-auto relative shadow-xl rounded-lg mx-10 mt-8 ms:mx-60 md:mx-60">
-  <table class="w-full text-lg text-gray-600">
-    <tbody>
-      <tr class="bg-sky-200">
-        <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap"><%= User.human_attribute_name :name %>:</th>
-        <td class="w-100 text-left"><%= @user.name %></td>
-      </tr>
-      <tr class="bg-gray-200">
-        <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap"><%= User.human_attribute_name :living_place %>:</th>
-        <td class="w-100 text-left"><%= User.prefecture_enums.key(@user.living_place) %></td>
-      </tr>
-      <tr class="bg-sky-200">
-        <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap">
-          <%= User.human_attribute_name :favorite_liquor_type %>:
-        </th>
-        <td class="w-100 text-left"><%= @user.favorite_liquor_type_i18n %></td>
-      </tr>
-      <tr class="bg-gray-200">
-        <th scope="row" class="w-8 py-4 px-6 text-right align-middle">
-          <%= User.human_attribute_name :self_introduction %>:
-        </th>
-        <td class="w-100 text-left py-4 pr-8 whitespace-pre"><%= @user.self_introduction %></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<% if current_user == @user %>
-  <div class="flex">
-    <div class="relative inline-flex my-4 ml-16 md:mx-60 text-base font-bold text-blue-700">
-      <%= link_to "プロフィールを編集", edit_user_path %>
+  <div class="flex md:flex-row md:max-w-full items-center justify-center pt-12 mx-10">
+    <%= image_tag "#{@user.avatar}", size: "200x200", class: "rounded-lg bg-white" %>
+  </div>
+  <% if current_user == @user %>
+    <div class="text-center text-base font-bold pt-2 text-blue-700">
+      <%= link_to t('.edit'), edit_user_path %>
+    </div>
+  <% end %>
+  <div class="overflow-x-auto grid grid-cols-5 md:grid-cols-6">
+    <table class="col-start-2 col-span-3 md:col-start-3 md:col-span-2 w-full mt-3 mb-8 text-base md:text-lg text-gray-600">
+      <tbody>
+        <tr class="bg-violet-200">
+          <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap"><%= User.human_attribute_name :name %>:</th>
+          <td class="w-100 text-left"><%= @user.name %></td>
+        </tr>
+        <tr class="bg-gray-200">
+          <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap"><%= User.human_attribute_name :living_place %>:</th>
+          <td class="w-100 text-left"><%= User.prefecture_enums.key(@user.living_place) %></td>
+        </tr>
+        <tr class="bg-violet-200">
+          <th scope="row" class="w-8 py-4 px-6 text-right whitespace-nowrap">
+            <%= User.human_attribute_name :favorite_liquor_type %>:
+          </th>
+          <td class="w-100 text-left"><%= @user.favorite_liquor_type_i18n %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="text-gray-600 grid grid-cols-8 md:grid-cols-10 pb-12"> 
+    <div class="col-start-2 col-span-6 md:col-start-4 md:col-span-4 rounded-lg px-8 pt-3 pb-6 bg-cyan-200">
+        <p class="py-3 font-bold">
+          <%= User.human_attribute_name :self_introduction %>
+        </p>
+        <p class="text-left break-words whitespace-pre-line"><%= @user.self_introduction %></p>
     </div>
   </div>
-<% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,8 +31,12 @@ ja:
     create:
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
+    show:
+      edit: 'プロフィールを編集する'
     edit:
       title: 'プロフィール編集'
+      delete: '画像を削除する'
+      not_selected: '未設定'
     update:
       success: 'プロフィールを更新しました'
       fail: 'プロフィールの更新に失敗しました'


### PR DESCRIPTION
## 概要

- ` users/show`ページのレイアウト修正
1. `self_introduction`欄をテーブルから切り離し
　テーブル上の他の要素(`name`,`living_place`,`favorite_liquor_type`)に対して幅を広く取ったほうが見やすいため修正。
2. プロフィール編集へのリンクを最下部からアバター下に変更

- `users/edit`ページのレウアウト修正
1. クラスの記述にまとめられる部分や記述場所が不適格なものがあったので修正。
2. 「画像を削除する」の表示位置を項目名の横に移動。
3. ユーザー名の表示欄を追加。

- viewに直接書いていた文章を`ja.yml`ファイルに記述。

## 確認方法
1. ログインしてメニューバーからプロフィールへ飛んでください。
4. テーブルと`self_introduction`部分をご確認ください。
5. 上記に併せて`users/edit`へのリンクの表示位置が変更されていることをご確認ください。
6. 「プロフィールを編集する」リンクから`users/edit`へ移動してください。
7. 「画像を削除する」の表示位置が変更されていることをご確認ください。
8. ユーザー名がアバターの下に追加されていることをご確認ください。

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義する。
例：
- [x]  rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認
