### PR TITLE
Add: [users_controller]before_actionを追加#147

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update destroy]
+  before_action :require_user_ownership, only: %i[edit update destroy]
   skip_before_action :require_login, only: %i[new create]
 
   def index
@@ -55,5 +56,12 @@ class UsersController < ApplicationController
 
   def user_profile_params
     params.require(:user).permit(:avatar, :avatar_cache, :remove_avatar, :living_place, :favorite_liquor_type, :self_introduction)
+  end
+
+  def require_user_ownership
+    return if @user.id == current_user.id
+
+    redirect_back_or_to root_path, danger: t('defaults.message.not_authorized')
+    nil
   end
 end


### PR DESCRIPTION
## 概要

- `users_controller`に`before_action :require_user_ownership`を追加。
- `edit`/ `update`/ `destroy`アクションにアクセス制限を設けた。

## 確認方法

行った修正をレビュアーが確認するための手順を記載する。
例：
1. ログインしてユーザー一覧にアクセスしてください。
2. 自分以外のユーザーをクリックしてください。
3. ユーザープロフィール画面に移動したらURLの末尾に`/edit`を加えてアクセスしてください。
4. 「権限がありません」というアラートが表示される。

## チェックリスト
- [ ] rubocopによるLintチェック
