### PR TITLE
Fix: users/indexのレイアウトを修正#152

### DIFF
--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,8 +1,8 @@
 <%= link_to user_path(user) do %>
-  <div class="flex flex-col items-center py-5 px-5">
+  <div class="flex flex-col items-center py-5 px-2">
     <% if user.avatar %>
-      <%= image_tag "#{user.avatar}", class: "object-cover w-20 h-20 rounded-full bg-white md:w-40 md:h-40 md:rounded-full" %>
+      <%= image_tag "#{user.avatar}", class: "object-cover w-15 h-15 rounded-full bg-white md:w-40 md:h-40 md:rounded-full" %>
     <% end %>
-    <h5 class="mb-1 text-base md:text-lg font-medium text-blue-700"><%= user.name %></h5>
+    <h5 class="mb-1 text-base md:text-lg font-medium truncate text-blue-700"><%= truncate(user.name, length: 8) %></h5>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
- ユーザー一覧画面のレイアウトを修正。
1. ユーザー名が長い場合に折り返して表示されることによるレイアウト崩れを修正。
2. 画面のサイズが小さい場合にアバターの円が潰れてしまうのでサイズを変更。

## 確認方法

行った修正をレビュアーが確認するための手順を記載する。
例：
1. ログインしてください。
2. メニューバーよりユーザー一覧へアクセスしてください。
3. 8文字以上のユーザー名は「...」で省略されていることをご確認ください。
4. ユーザーアバターが画面幅が小さいときに潰れていないことをご確認ください。

## チェックリスト
- [x]  rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認
