### PR TITLE
Add: before_login_headerにロゴを追加

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <nav class="bg-amber-400 px-3.5 py-2">
   <div class="container flex flex-wrap justify-between items-center">
     <%= link_to root_path do %>
-      <span class="font-semibold text-xl tracking-tight rounded-md text-blue-700 hover:text-white first-line:">お酒のふるさと</span>
+      <%= image_tag 'header_logo.png', size:'300x200', class: "rounded-lg w-40 md:w-72" %>
     <% end %>
   
     <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-100 rounded-lg md:hidden hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="navbar-default" aria-expanded="false">


### PR DESCRIPTION
## 概要
2272f4809552722d66438d0cc036040bf3925ba9 にて`before_login_header`へのlogo表示コードの記述が漏れておりました。こちらで修正致しました。

## 確認方法
1. ログイン前の状態でヘッダーの画像をご確認ください。
