### PR TITLE
Fix: ルーティングとサイトマップの修正#158

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
-  get '/sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials[:aws][:S3_sitemap_bucket_name]}/sitemaps/sitemap.xml.gz")
+  get '/sitemap', to: redirect("https://#{Rails.application.credentials[:aws][:S3_sitemap_bucket_name]}.s3.ap-northeast-1.amazonaws.com/sitemap.xml.gz")
   root to: 'home#top'
   resources :breweries, only: %i[index show] do
     get 'nearby_hotels', on: :member, to: 'nearby_hotels#index'

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk-s3'
 
 SitemapGenerator::Sitemap.default_host = 'https://www.osake-no-furusato.jp/'
-SitemapGenerator::Sitemap.sitemaps_host = "http://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials[:aws][:S3_sitemap_bucket_name]}/sitemaps/sitemap.xml.gz"
+SitemapGenerator::Sitemap.sitemaps_host = "https://#{Rails.application.credentials[:aws][:S3_sitemap_bucket_name]}.s3.ap-northeast-1.amazonaws.com/sitemap.xml.gz"
 SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsSdkAdapter.new(Rails.application.credentials[:aws][:S3_sitemap_bucket_name],
                                                                         aws_access_key_id: Rails.application.credentials[:aws][:access_key_id],
                                                                         aws_secret_access_key: Rails.application.credentials[:aws][:secret_access_key],


### PR DESCRIPTION
## 概要
S3上ではサイトマップをダウンロードできたが、URLでアクセスするとダウンロードができなかった。
確認したところ、ルーティングと`sitemap.rb`内の`sitemap.host`が誤っていたため修正。

## 確認方法
- `/sitemap`からサイトマップがダウンロードできることをご確認ください。

## チェックリスト
- [x] rubocopによるLintチェック

