### PR TITLE
Fix: パスワードリセットのためmailerの設定を修正#97

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -2,9 +2,9 @@ class ContactMailer < ApplicationMailer
   def send_contact_form(contact)
     @contact = contact
     mail(
-        from: contact.email,
-        to: Rails.application.credentials[:mailer].to_s,
-        subject: t('defaults.contact_form')
-      )
+      from: contact.email,
+      to: Rails.application.credentials[:mailer].to_s,
+      subject: t('defaults.contact_form')
+    )
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,9 +3,9 @@ class UserMailer < ApplicationMailer
     @user = User.find user.id
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(
-        from: Rails.application.credentials[:mailer].to_s,
-        to: user.email,
-        subject: t('defaults.password_reset')
-      )
+      from: Rails.application.credentials[:mailer].to_s,
+      to: user.email,
+      subject: t('defaults.password_reset')
+    )
   end
 end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
 default_url_options:
-  { protocol: 'https', host: 'osake-no-furusato.jp' }
+  host: 'osake-no-furusato.jp'


### PR DESCRIPTION
## 概要
本番環境でパスワードリセットメールに記載されているリンクが無効になっていました。
開発環境では問題なくリンクが有効です。
本番環境のメールに記載されているリンクを開いてアドレスバーから確認すると頭についた`https://`が問題になっており、この部分を削除すると正しくリンクされました。`config/setting/production.yml`が原因だと推測し修正しました。

## 確認方法
1. パスワードリセットを実行し、メールのリンクを開いて有効であることをご確認ください。

## チェックリスト
- [x] rubocopによるLintチェック
