### PR TITLE
Fix: 本番環境の設定修正#97

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
 default_url_options:
-  host: 'osake-no-furusato.jp'
+  host: 'https://www.osake-no-furusato.jp'


### PR DESCRIPTION
## 概要
3241e5d で行った修正後も本番環境でURLが無効になっており修正ができておりませんでした。
アドレスバーでパスワードリセットのルーティング部分の直前が`https://www.osake-no-furusato.jp`になっているときは正常に開くことを確認。本番環境のhostを`https://www.osake-no-furusato.jp`に修正。


## 確認方法
1. パスワードリセットを実行し、自動送信メールに記載されているリンクが有効であることをご確認ください。
