### PR TITLE
Fix: パスワードリセットのビュー修正#164

### DIFF
--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -5,23 +5,25 @@
       <h1><%= t('.title') %></h1>
     </div>
     <h1 class='mb-4 text-center text-base text-gray-500'>新しいパスワードを入力してください</h1>
-    <%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
-      <%= render "shared/error_messages", object: f.object %>
-      <div class='mt-4'>
-        <%= f.label :email, class: "text-sm font-bold text-gray-900" %><br>
-        <%= @user.email %>
-      </div>
-      <div class='mt-4'>
-        <%= f.label :password, class: "text-sm font-bold text-gray-900" %>
-        <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
-      </div>
-      <div class='mt-4'>
-        <%= f.label :password_confirmation, class: "text-sm font-bold text-gray-900" %>
-        <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 mb-8 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
-      </div>
-      <div class='actions text-center'>
-        <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
-      </div>
-    <% end %>
+    <div class='flex flex-col justify-center mt-8 mb-6 mx-8'>
+      <%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
+        <%= render "shared/error_messages", object: f.object %>
+        <div class='mt-4'>
+          <%= f.label :email, class: "text-sm font-bold text-gray-900" %><br>
+          <%= @user.email %>
+        </div>
+        <div class='mt-4'>
+          <%= f.label :password, class: "text-sm font-bold text-gray-900" %>
+          <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
+        </div>
+        <div class='mt-4'>
+          <%= f.label :password_confirmation, class: "text-sm font-bold text-gray-900" %>
+          <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 mb-8 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
+        </div>
+        <div class='actions text-center'>
+          <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -4,20 +4,21 @@
     <div class='text-center my-8'>
       <h1><%= t('.title') %></h1>
     </div>
-    <div class='text-base text-gray-500'>
-      <h1>登録メールアドレスを入力してください。</h1>
-      <h1>パスワードリセット手続きのメールが送信されます。</h1>
-    </div>
-    <%= form_with url: password_resets_path, local: true do |f| %>
-      <div class='form-group'>
-        <div class='my-4 text-sm font-bold text-gray-900'>
-          <%= f.label :email, t(User.human_attribute_name(:email)) %>
-        </div>
-          <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block mb-8 w-full p-2.5" %>
-        <div class='text-center'>
-          <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
-        </div>
+    <div class='flex flex-col justify-center mt-8 mb-6 mx-8'>
+      <div class='text-base text-gray-500 mb-8'>
+        <h1>登録メールアドレスを入力してください。パスワードリセット手続きのメールが送信されます。</h1>
       </div>
-    <% end %>
+      <%= form_with url: password_resets_path, local: true do |f| %>   
+          <div class='form-group'>
+            <div class='my-4 text-sm font-bold text-gray-900'>
+              <%= f.label :email, t(User.human_attribute_name(:email)) %>
+            </div>
+              <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block mb-8 w-full p-2.5" %>
+            <div class='text-center'>
+              <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+            </div>
+          </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -21,9 +21,11 @@
           <%= f.submit t('defaults.login'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
       </div>
     <% end %>
-    <div class='text-center text-base'>
-      <%= link_to (t '.to_register_page'), new_user_path, class: "mr-6" %>
-      <%= link_to (t '.password_forget'), new_password_reset_path %>
+    <div class="flex flex-col justify-center items-center md:flex-row">
+      <div class='text-center text-base'>
+        <%= link_to (t '.to_register_page'), new_user_path, class: "mr-6 inline-flex h-10" %>
+        <%= link_to (t '.password_forget'), new_password_reset_path, class: "inline-flex h-10" %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- ログイン画面下部のリンク「新規ユーザー登録」と「パスワードをお忘れの方はこちら」を最小幅768pxサイズの時は縦並びになるよう修正。
- パスワードリセット関連のビューをレスポンシブ対応に修正。
具体的にはフォームの両端に隙間がない状態から空白を作った上で中央寄せに致しました。

## 確認方法
スマートフォンサイズの画面サイズで下記ご確認ください。
1. ログイン画面でリンク「新規ユーザー登録」と「パスワードをお忘れの方はこちら」が縦並びになっていることをご確認ください。
2. ログイン画面より「パスワードをお忘れの方はこちら」へアクセス。
3. パスワードリセット申請画面よりレイアウトをご確認ください。
4. パスワードリセット申請を行い、自動送信メールのリンクをクリック。
5. パスワードリセット画面のレイアウトをご確認ください。

## チェックリスト
- [x] rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認
