### PR TITLE
Fix: レビュー機能の修正#169

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("jquery")

--- a/app/javascript/packs/edit_review.js
+++ b/app/javascript/packs/edit_review.js
@@ -1,70 +1,77 @@
 $(function() {
   //編集押下
   $(document).on("click", '.js-edit-review-button', function(e) {
-      e.preventDefault();
-      const reviewId = $(this).data("review-id")
-      switchToEdit(reviewId)
+    e.preventDefault();
+    const reviewId = $(this).data("review-id")
+    switchToEdit(reviewId)
   })
   //キャンセル押下
   $(document).on("click", '.js-button-edit-review-cancel', function() {
-      clearErrorMessages()
-      const reviewId = $(this).data("review-id")
-      switchToLabel(reviewId)
+    clearErrorMessages()
+    const reviewId = $(this).data("review-id")
+    switchToLabel(reviewId)
   })
   //更新押下
-  $(document).on("click", '.js-button-review-update', function() {
-      clearErrorMessages()
-      const reviewId = $(this).data("review-id")
+  $(document).on("click", '.js-button-review-update', function(event) {
+    const $button = $(event.target);
+    if ($button.prop("disabled")) {
+      return;
+    }
+    $button.prop("disabled", true); 
+    clearErrorMessages()
+      const reviewId = $button.data("review-id")
       submitReview($("#js-textarea-review-" + reviewId).val(), reviewId)
-          .then(result => {
-              $("#js-review-" + result.review.id).html(result.review.content.replace(/\r?\n/g, '<br>'))
-              switchToLabel(result.review.id)
-          })
-          .catch(result => {
-              const reviewId = result.responseJSON.review.id
-              const messages = result.responseJSON.errors.messages
-              showErrorMessages(reviewId, messages)
-          })
+        .then(result => {
+            $("#js-review-" + result.review.id).html(result.review.content.replace(/\r?\n/g, '<br>'))
+            switchToLabel(result.review.id)
+        })
+        .catch(result => {
+            const reviewId = result.responseJSON.review.id
+            const messages = result.responseJSON.errors.messages
+            showErrorMessages(reviewId, messages)
+        })
+        .finally(() => {
+          $button.prop("disabled", false);
+        });
   })
+  //更新用設定
+  function submitReview(content, reviewId) {
+    return new Promise(function(resolve, reject) {
+      $.ajax({
+        type: 'PATCH',
+        url: '/reviews/' + reviewId,
+        data: {
+          review: {
+            content: content,
+            "authenticity_token": $("#authenticity_token").val()
+            },
+        },
+        headers: {
+          'X-CSRF-Token' : $('meta[name="csrf-token"]').attr('content')
+        },
+        }).done(function (result) {
+            resolve(result)
+        }).fail(function (result) {
+            reject(result)
+        });
+    })
+}
   //編集フォームを隠す
   function switchToLabel(reviewId) {
-      $("#js-textarea-review-box-" + reviewId).hide()
-      $("#js-review-" + reviewId).show()
+    $("#js-textarea-review-box-" + reviewId).hide()
+    $("#js-review-" + reviewId).show()
   }
   //編集フォーム表示
   function switchToEdit(reviewId) {
-      $("#js-review-" + reviewId).hide()
-      $("#js-textarea-review-box-" + reviewId).show()
+    $("#js-review-" + reviewId).hide()
+    $("#js-textarea-review-box-" + reviewId).show()
   }
-
+  //エラーメッセージ表示
   function showErrorMessages(reviewId, messages) {
-      $('<p class="error_messages text-danger">' + messages.join('<br>') + '</p>').insertBefore($("#js-textarea-review-" + reviewId))
+    $('<p class="error_messages text-danger">' + messages.join('<br>') + '</p>').insertBefore($("#js-textarea-review-" + reviewId))
   }
-  //編集内容投稿
-  function submitReview(content, reviewId) {
-      return new Promise(function(resolve, reject) {
-          $.ajax({
-              type: 'PATCH',
-              url: '/reviews/' + reviewId,
-              data: {
-                  review: {
-                      content: content,
-                      "_method": "put",
-                      "authenticity_token": $("#authenticity_token").val()
-                  },
-              },
-              headers: {
-                'X-CSRF-Token' : $('meta[name="csrf-token"]').attr('content')
-              },
-          }).done(function (result) {
-              resolve(result)
-          }).fail(function (result) {
-              reject(result)
-          });
-      })
-  }
-
+  //エラーメッセージ削除
   function clearErrorMessages() {
-      $("p.error_messages").remove()
+    $("p.error_messages").remove()
   }
 });

--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -67,14 +67,11 @@
 
   <!-- レビューエリア -->
   <h2 class="text-xl font-semibold text-center leading-8 text-white bg-blue-400 lg:mx-20 md:mx-0 mt-6 mb-4">みんなのレビュー</h2>
-  <% if @reviews.present? %>
-    <%= render 'reviews/reviews', { reviews: @reviews } %>
-    <div class="mb-4 text-gray-500 font-bold">
-      <%= paginate @reviews %>
-    </div>
-  <% else %>
-    <p class="text-gray-600 text-center text-lg my-6">⚠︎レビューがまだありません。</p>
-  <% end %>
+  <%= render 'reviews/reviews', { reviews: @reviews } %>
+  <div class="mb-4 text-gray-500 font-bold">
+    <%= paginate @reviews %>
+  </div>
+
   <!-- レビューフォーム -->
   <% if logged_in? %>
     <%= render 'reviews/form', { brewery: @brewery, review: @review } %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -19,7 +19,7 @@
           </a>
         </li>
         <li>
-          <%= link_to review_path(review), class: "js-delete-review-button", method: :delete, data: { confirm: 'レビューを削除しますか？'} do %>
+          <%= link_to review_path(review), method: :delete, data: { confirm: 'レビューを削除しますか？'} do %>
             <i class="fa-solid fa-trash"></i>
           <% end %>
         </li>
@@ -29,7 +29,7 @@
     <div id="js-textarea-review-box-<%= review.id %>" style="display: none;">
       <textarea id="js-textarea-review-<%= review.id %>" class="bg-gray-50 rounded-lg w-full h-24 border-gray-400 focus:ring-blue-500 focus:border-blue-500"><%= review.content %></textarea></br>
       <button class="js-button-review-update text-sm bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 border-2 border-blue-700 rounded mr-3" data-review-id="<%= review.id %>">更新</button>
-      <button class="js-button-edit-review-cancel text-sm bg-gray-500 hover:bg-gray-700 text-white py-1 px-2 border-2 border-gray-700 rounded"" data-review-id="<%= review.id %>">キャンセル</button>
+      <button class="js-button-edit-review-cancel text-sm bg-gray-500 hover:bg-gray-700 text-white py-1 px-2 border-2 border-gray-700 rounded" data-review-id="<%= review.id %>">キャンセル</button>
     </div>
   </td>
 <tr>


### PR DESCRIPTION
## 概要
- レビュー機能の修正

1. 各`brewery`の`show`ページで最初のレビュー投稿時のみリロードしないと反映されていなかった。
- 原因：jQueryの要素追加部分に指定していたidがレビュー0件の時に存在しなかったためリロードしないと非同期で表示されていなかった。（`breweries/show.html.erb`上の条件分岐が原因)
- 修正：
・ `reviews/_reviews`パーシャルは維持したまま`breweries/show`を修正。`breweries/show`に記載していたレビュー表示部分のif文があると、非同期で追加された要素が追加されても「レビューがありません」と表示されてしまうので条件分岐を削除。 
・また、条件分岐を削除してレビューの有無に関わらず`<%= render 'reviews/reviews', { reviews: @reviews } %>`を表示することで`reviews/create.js.erb`上で要素追加先に設定していた`id="js-reviews"`が常に存在し非同期で追加できるようにした。

2. レビューの更新をすると重複してリクエストが送信されていた。ページ上に存在するレビューの数だけリクエストが飛んでおり、バリデーションに引っかかった際はエラー文もリクエストの数だけ表示されていた。
- 原因：なぜリクエストが重複して生成されるのか特定できなかった。ログや開発者ツール上で確認できるリクエストの内容やエラー文はレビューidまで完全に同一で`show`ページ上に表示されている他のレビューのクリックイベントが同時発動しているようではなかった。
- 修正：更新ボタン(`js-button-review-update`)が一度クリックされた後は処理が完了するまでクリックを無効化し、イベントが重複して発生しないよう設定。


## 確認方法
1. レビュー未登録の`brewery`詳細画面へアクセス。
2. レビューを投稿し、リロードなしで表示されていることをご確認ください。
3. 続いてバリデーションに引っ掛かるよう、9文字以下でレビューを投稿してください。
4. エラー文が1つのみ表示されることをご確認ください。

## チェックリスト
-  `rubocop`によるLintチェック
- デベロッパーツールによるUI確認

## コメント
レビューが0件の時、「レビューはまだありません」と表示させたい。投稿機能が非同期なので「レビューはまだありません」はajaxで表示させるコードを書く必要があるので、どうしたら実装できるか調べてからコード修正をしたい。
