### PR TITLE
Fix: 管理画面のレイアウト変更

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -53,4 +53,21 @@ ActiveAdmin.register User do
       row :access_count_to_reset_password_page
     end
   end
+
+  index do
+    selectable_column
+    column :id
+    column :name
+    column :email
+    column :avatar do |user|
+      image_tag(user.avatar.url, style: 'max-width: 50px;')
+    end
+    column :living_place do |user|
+      User.prefecture_enums.key(user.living_place)
+    end
+    column :favorite_liquor_type
+    column :self_introduction
+    column :role
+    actions 
+  end
 end


### PR DESCRIPTION
## 概要
管理画面のユーザー一覧のレイアウトを変更。
レビューの文字数が多いと極端に行幅が広くなってしまうので一覧として見辛い→パスワード関連の情報は詳細画面で確認できれば十分なので一覧では非表示にした。

## 確認方法
1. 管理画面のユーザー一覧にアクセスしてレイアウトをご確認ください。

## コメント
本件から逸れますが、ratyファイルは無くても動くようなので削除しました。