### PR TITLE
Add: ユーザー削除機能を追加#174

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/BlockLength:
     - 'Gemfile'
     - 'config/**/*'
     - 'spec/**/*_spec.rb'
+    - 'app/**/*users.rb'
 
 Metrics/ClassLength:
   CountComments: false

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -68,6 +68,6 @@ ActiveAdmin.register User do
     column :favorite_liquor_type
     column :self_introduction
     column :role
-    actions 
+    actions
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,8 +40,8 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user.detroy
-    redirect_to login_path, success: '削除しました'
+    @user.destroy
+    redirect_to root_path, success: t('defaults.message.deleted', item: 'アカウント')
   end
 
   private

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -3,19 +3,19 @@
   <div class='flex flex-col justify-center mt-8 mb-6 mx-8'>
     <div class='mt-4'>
       <%= f.label :name, class: "block mb-2 text-sm font-bold text-gray-900" %>
-      <%= f.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "酒蔵　巡子", required: "", id: 'user_name' %> 
+      <%= f.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "酒蔵　巡子" %> 
     </div>
     <div class='mt-4'>
       <%= f.label :email, class: "block mb-2 text-sm font-bold text-gray-900" %>
-      <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "osake_no_furusato@example.com", required: "", id: 'user_email' %> 
+      <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "osake_no_furusato@example.com" %> 
     </div>
     <div class='mt-4'>
       <%= f.label :password, class: "block mb-2 text-sm font-bold text-gray-900" %>
-      <%= f.password_field :password, class:"bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "••••••••••", required: "", id: 'user_password' %> 
+      <%= f.password_field :password, class:"bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "••••••••••" %> 
     </div>
     <div class='mt-4'>
       <%= f.label :password_confirmation, class:"block mb-2 text-sm font-bold text-gray-900" %>
-      <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 mb-8", placeholder: "••••••••••", required: "", id: 'user_password_confirmation' %> 
+      <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 mb-8", placeholder: "••••••••••" %> 
     </div>
     <%= f.submit (t 'defaults.register'), class: "text-white bg-gradient-to-r from-green-500 via-green-600 to-green-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-2 cursor-pointer" %>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'preview_image' %>
 <% content_for :title, t('.title')%>
 <div class= 'flex flex-col items-center'>
   <div class='w-full max-w-md'>
@@ -46,7 +45,9 @@
           <%= f.text_area :self_introduction, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 w-full p-2.5 mb-1 h-40", placeholder: @user.self_introduction %>
         </div>
         <%= f.submit t('defaults.update'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+        <%= link_to "アカウントを削除", user_path(current_user), method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: "アカウント") }, class: "text-white bg-gradient-to-r from-red-500 via-red-600 to-red-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 my-10 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
       </div>
     <% end %>
   </div>
 </div>
+<%= javascript_pack_tag 'preview_image' %>


### PR DESCRIPTION
## 概要
- プロフィール編集画面にアカウント削除ボタンを作成。

## 確認方法
1. ナビゲーションバーよりプロフィールページにアクセスしてください。
2. 「プロフィールを編集する」より編集画面へ移動してください。
3. 最下部の「アカウントを削除する」ボタンをクリック。
4. 確認画面が表示されますのでOKをクリックして進んでください。
5. 削除が実行されトップページに遷移。削除成功のメッセージが表示されるのをご確認ください。

## チェックリスト
- [x] rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認

## コメント
本題より逸れますが、ユーザー登録フォーム(`users/_form.html.erb`)から不要なidを削除しました。また、 2170c36370ca695d57093b392739fd0ffff40b9b でLintチェックが漏れていた箇所を修正しました。
