### PR TITLE
Fix: 翻訳ファイルの整理#176

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,10 @@ class ApplicationController < ActionController::Base
   add_flash_types :success
 
   def not_authenticated
-    redirect_to login_path, alert: 'ログインしてください'
+    redirect_to login_path, alert: t('defaults.message.require_login')
   end
 
   def access_denied(_exception)
-    redirect_to root_path, alert: '管理者専用ページです'
+    redirect_to root_path, alert: t('defaults.message.admin_only')
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -17,7 +17,7 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.find(params[:id])
     @brewery = @review.brewery
     @review.destroy!
-    redirect_to brewery_path(@brewery), success: t('.success')
+    redirect_to brewery_path(@brewery), success: t('defaults.message.deleted', item: 'レビュー')
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,9 +32,9 @@ class UsersController < ApplicationController
     end
 
     if @user.update(user_profile_params)
-      redirect_to user_path(@user), success: t('.success')
+      redirect_to user_path(@user), success: t('defaults.message.updated', item: t('.profile'))
     else
-      flash.now[:danger] = t('.fail')
+      flash.now[:danger] = t('defaults.message.not_updated', item: t('.profile'))
       render :edit
     end
   end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -14,14 +14,14 @@
         </div>
         <div class='mt-4'>
           <%= f.label :password, class: "text-sm font-bold text-gray-900" %>
-          <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
+          <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
         </div>
         <div class='mt-4'>
           <%= f.label :password_confirmation, class: "text-sm font-bold text-gray-900" %>
-          <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 mb-8 focus:border-blue-500 block w-full p-2.5", required: "", id: "user_password" %>
+          <%= f.password_field :password_confirmation, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 mb-8 focus:border-blue-500 block w-full p-2.5" %>
         </div>
         <div class='actions text-center'>
-          <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+          <%= f.submit (t 'defaults.post'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -15,7 +15,7 @@
             </div>
               <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block mb-8 w-full p-2.5" %>
             <div class='text-center'>
-              <%= f.submit (t '.submit'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+              <%= f.submit (t 'defaults.post'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
             </div>
           </div>
       <% end %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -36,7 +36,7 @@
           </a>
         </li>
         <li>
-          <%= link_to review_path(review), method: :delete, data: { confirm: 'レビューを削除しますか？'} do %>
+          <%= link_to review_path(review), method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: 'レビュー')} do %>
             <i class="fa-solid fa-trash"></i>
           <% end %>
         </li>
@@ -45,8 +45,8 @@
     <%# 編集フォーム %>
     <div id="js-textarea-review-box-<%= review.id %>" style="display: none;">
       <textarea id="js-textarea-review-<%= review.id %>" class="bg-gray-50 rounded-lg w-full h-24 border-gray-400 focus:ring-blue-500 focus:border-blue-500"><%= review.content %></textarea></br>
-      <button class="js-button-review-update text-sm bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 border-2 border-blue-700 rounded mr-3" data-review-id="<%= review.id %>">更新</button>
-      <button class="js-button-edit-review-cancel text-sm bg-gray-500 hover:bg-gray-700 text-white py-1 px-2 border-2 border-gray-700 rounded" data-review-id="<%= review.id %>">キャンセル</button>
+      <button class="js-button-review-update text-sm bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 border-2 border-blue-700 rounded mr-3" data-review-id="<%= review.id %>"><%= t('defaults.update') %></button>
+      <button class="js-button-edit-review-cancel text-sm bg-gray-500 hover:bg-gray-700 text-white py-1 px-2 border-2 border-gray-700 rounded" data-review-id="<%= review.id %>"><%= t('defaults.cancel') %></button>
     </div>
   </td>
 <tr>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -10,13 +10,13 @@
           <div class='mb-2 font-bold'>
             <%= f.label :email, User.human_attribute_name(:email) %>
           </div>
-            <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", required:"", placeholder: "osake_no_furusato@example.com" %>
+            <%= f.email_field :email, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "osake_no_furusato@example.com" %>
         </div>
         <div class='text-gray-700 text-sm mb-12'>
           <div class='mb-2 font-bold'>
             <%= f.label :password, User.human_attribute_name(:password) %> 
           </div>
-            <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", required:"", placeholder: "••••••••••" %>
+            <%= f.password_field :password, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5", placeholder: "••••••••••" %>
         </div>
           <%= f.submit t('defaults.login'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,7 +7,7 @@
     <%= form_with model: @user, url: user_path, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="flex justify-center"> 
-        <%= image_tag @user.avatar.url, id: "preview", size: "200x200", accept: "image/*", class: "inline mb-4 rounded-md" %></br>
+        <%= image_tag @user.avatar.url, id: "preview", size: "150x150", accept: "image/*", class: "inline mb-4 rounded-md" %></br>
       </div>
       <div class="mx-8 mb-6 text-gray-700 text-sm font-bold">
         <%= User.human_attribute_name(:name) %>：<%= @user.name %>
@@ -18,7 +18,7 @@
           <% if @user.avatar? %>
             <label class="ml-4">
               <%= f.check_box :remove_avatar %>
-              <%= t('.delete') %>
+              <%= t('.delete_avatar') %>
             </label>
           <% end %>
         </div>
@@ -45,7 +45,7 @@
           <%= f.text_area :self_introduction, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 w-full p-2.5 mb-1 h-40", placeholder: @user.self_introduction %>
         </div>
         <%= f.submit t('defaults.update'), class: "text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
-        <%= link_to "アカウントを削除", user_path(current_user), method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: "アカウント") }, class: "text-white bg-gradient-to-r from-red-500 via-red-600 to-red-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 my-10 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
+        <%= link_to t('.delete_account'), user_path(current_user), method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: t('.account')) }, class: "text-white bg-gradient-to-r from-red-500 via-red-600 to-red-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-base px-5 py-3 my-10 text-center tracking-widest mr-2 mb-4 cursor-pointer" %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "#{@user.name}さんのプロフィール" %>
 <div class="bg-lime-100 min-h-screen">
   <div class="flex md:flex-row md:max-w-full items-center justify-center pt-12 mx-10">
-    <%= image_tag "#{@user.avatar}", size: "200x200", class: "rounded-lg bg-white" %>
+    <%= image_tag "#{@user.avatar}", size: "150x150", class: "rounded-lg bg-white" %>
   </div>
   <% if current_user == @user %>
     <div class="text-center text-base font-bold py-4 text-blue-700">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,13 +1,13 @@
 ja:
   defaults:
     login: 'ログイン'
-    register: '登録'
     logout: 'ログアウト'
+    register: '登録'
     edit: '編集'
-    update: '更新する'
     show: '詳細'
     delete: '削除'
-    password_reset: 'パスワードリセット'
+    update: '更新'
+    cancel: 'キャンセル'
     search_word: '検索ワード'
     unspecified: '指定なし'
     post: '送信'
@@ -18,14 +18,14 @@ ja:
       updated: '%{item}を更新しました'
       not_updated: '%{item}を更新できませんでした'
       deleted: '%{item}を削除しました'
-      delete_confirm: '削除しますか？'
-      not_authenticated: 'ログインしてください'
+      delete_confirm: '%{item}を削除しますか？'
       not_authorized: '権限がありません'
+      admin_only: '管理者専用ページです'
   users: # controllers/usersに対応
     index:
       title: 'ユーザー一覧'
-      no_result: 登録ユーザーが存在しません''
-    new: # users/newアクションに対応
+      no_result: '登録ユーザーが存在しません'
+    new:
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'
     create:
@@ -35,14 +35,14 @@ ja:
       edit: 'プロフィールを編集する'
     edit:
       title: 'プロフィール編集'
-      delete: '画像を削除する'
+      delete_avatar: '画像を削除する'
       not_selected: '未設定'
+      account: 'アカウント'
+      delete_account: 'アカウントを削除する'
     update:
-      success: 'プロフィールを更新しました'
-      fail: 'プロフィールの更新に失敗しました'
+      profile: 'プロフィール'
   user_sessions:
     new:
-      require_login: 'ログインしてください'
       title: 'ログイン'
       to_register_page: '新規ユーザー登録'
       password_forget: 'パスワードをお忘れの方はこちら'
@@ -67,17 +67,13 @@ ja:
     create:
       success: 'レビューを投稿しました'
       fail: 'レビューの投稿に失敗しました'
-    destroy: 
-      success: 'レビューを削除しました'
   password_resets:
     new:
       title: 'パスワードリセット申請'
-      submit: '送信'
     create:
       success: 'パスワードリセット手順を送信しました'
     edit:
       title: 'パスワードリセット'
-      submit: '送信'
     update:
       success: 'パスワードを変更しました'
       fail: 'パスワード変更に失敗しました'


### PR DESCRIPTION
## 概要
`config/locales/views/ja.yml`の翻訳コードを整理。
・不要な翻訳を削除。
・まとめられる翻訳を集約。
・view上にダイレクトに書いていたもので翻訳ファイルに移せそうなものは新規作成。

## 確認方法
1. `general`のユーザーとしてログインし`/admin`へアクセス。アラートメッセージが正常に表示されていることを確認。
2. レビュー削除時に正常にメッセージが表示されていることを確認。
3. プロフィール更新を実行。成功時および失敗時に正常にメッセージが表示される。
4. パスワードリセット（/`password_resets/new`）にアクセスし、「送信」ボタンが表示されている。
5. パスワード編集（/`password_resets/edit`）にアクセスし、「送信」ボタンが表示されている。
6. レビューの編集アイコンをクリックし「更新」ボタンと「キャンセル」ボタンが表示される。
7. レビューの削除アイコンをクリックすると確認画面のメッセージが正常に表示される。
8. プロフィール編集画面にアクセス。チェックボックス「画像を削除する」と「アカウントを削除」ボタンが表示される。
9. アカウント削除をクリックすると確認画面のメッセージが正常に表示される。

## チェックリスト
- [x]  rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認

## コメント
確認事項が多いのでテストを作成いたします。