### PR TITLE
Add: breweriesテーブルにnot_null制約を追加#180

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,7 +4,7 @@
     <div class='text-center my-8 text-neutral-500 text-lg'>
       <h1><%= t('.title') %></h1>
     </div>
-    <%= form_with model: @user, url: user_path, local: true do |f| %>
+    <%= form_with model: @user, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="flex justify-center"> 
         <%= image_tag @user.avatar.url, id: "preview", size: "150x150", accept: "image/*", class: "inline mb-4 rounded-md" %></br>

--- a/db/migrate/20230921053734_add_not_null_constraint_to_breweries.rb
+++ b/db/migrate/20230921053734_add_not_null_constraint_to_breweries.rb
@@ -1,0 +1,9 @@
+class AddNotNullConstraintToBreweries < ActiveRecord::Migration[6.1]
+  def up
+    change_column :breweries, :name, :string, null: false
+  end
+
+  def down
+    change_column :breweries, :name, :string, null: true
+  end
+end

--- a/db/migrate/20230921054825_add_index_to_breweries.rb
+++ b/db/migrate/20230921054825_add_index_to_breweries.rb
@@ -1,0 +1,5 @@
+class AddIndexToBreweries < ActiveRecord::Migration[6.1]
+  def change
+    add_index :breweries, [:name, :address], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_08_051347) do
+ActiveRecord::Schema.define(version: 2023_09_21_054825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2023_09_08_051347) do
   end
 
   create_table "breweries", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.string "address"
     t.string "phone_number"
     t.string "prefecture"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2023_09_08_051347) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "place_id"
     t.string "image"
+    t.index ["name", "address"], name: "index_breweries_on_name_and_address", unique: true
   end
 
   create_table "keeps", force: :cascade do |t|


### PR DESCRIPTION
## 概要
`breweries`テーブルの`name`カラムに`not_null`制約を付けました。
`name`と`address`は同じ組み合わせが複数存在することはないので`index`を付けました。

## コメント
`users/edit.html.erb`に不要な箇所を見つけたので削除しました。
