### PR TITLE
Fix: ページネーションのCSSを修正#182

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,8 @@
   span{
       text-align: center;
       width: 50px;
+      font-weight: bold;
+      color: #6b7280;
       :hover{
           background-color:#f3f3f3;
       }

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -6,7 +6,9 @@
   <% else %>
     <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_result') %></p> 
   <% end %>
-  <div class="pb-8 text-gray-500 font-bold">
-    <%= paginate @breweries %>
+  <div class="pagination">
+  <div class="pb-8">
+    <%= paginate @breweries, window:2 %>
+  </div>
   </div>
 </div>

--- a/app/views/breweries/keeps.html.erb
+++ b/app/views/breweries/keeps.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_keeps') %></p> 
   <% end %>
-  <div class="pb-8 text-gray-500 font-bold">
-    <%= paginate @keep_breweries %>
+  <div class="pb-8">
+    <%= paginate @keep_breweries, window:2 %>
   </div>
 </div>

--- a/app/views/breweries/likes.html.erb
+++ b/app/views/breweries/likes.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_likes') %></p> 
   <% end %>
-  <div class="pb-8 text-gray-500 font-bold">
-    <%= paginate @like_breweries %>
+  <div class="pb-8">
+    <%= paginate @like_breweries, window:2 %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
     <% else %>
       <p class="text-center text-lg text-gray-700 bg-cyan-400"><%= t('.no_reslt') %></p> 
     <% end %>
-    <div class="py-10 text-gray-500 font-bold">
+    <div class="py-10">
       <%= paginate @users, window:2 %>
     </div>
   </div>


### PR DESCRIPTION
## 概要
ページネーションのCSSを修正しました。
- オプション`window:2`を全ての箇所に付けました。
- `assets/stylesheets/application.scss`にCSSの定義がありながら`view`ファイルにスタイルを書いてしまっていたため、viewの定義を削除し`application.scss`に記述しました。

## 確認方法
- ページネーションを含む下記のページをご確認ください。
1. `breweries/keeps`
2. `breweries/likes`
3. `breweries/index`
4. `users/index`

## チェックリスト
- [x]  rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認