### PR TITLE
Add: reviewsテーブルにvisit_dateカラムを追加#189

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,4 +1,21 @@
 class ReviewsController < ApplicationController
+  def create
+    visit_date_param = params[:review][:visit_date]
+
+    if visit_date_param.blank?
+      visit_date = nil
+    else
+      year = params[:review][:visit_date].split('-')[0].to_i
+      month = params[:review][:visit_date].split('-')[1].to_i
+      day = 1
+      visit_date = Date.new(year, month, day)
+    end
+
+    @review = current_user.reviews.build(review_params)
+    @review.visit_date = visit_date
+    @review.save
+  end
+
   def update
     @review = current_user.reviews.find(params[:id])
     if @review.update(review_update_params)
@@ -6,11 +23,6 @@ class ReviewsController < ApplicationController
     else
       render json: { review: @review, errors: { messages: @review.errors.full_messages } }, status: :bad_request
     end
-  end
-
-  def create
-    @review = current_user.reviews.build(review_params)
-    @review.save
   end
 
   def destroy
@@ -23,10 +35,10 @@ class ReviewsController < ApplicationController
   private
 
   def review_params
-    params.require(:review).permit(:content, :star).merge(brewery_id: params[:brewery_id])
+    params.require(:review).permit(:content, :star, :visit_date).merge(brewery_id: params[:brewery_id])
   end
 
   def review_update_params
-    params.require(:review).permit(:content, :star)
+    params.require(:review).permit(:content, :star, :visit_date)
   end
 end

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -3,7 +3,7 @@
     <% render 'shared/error_messages', object: f.object %>
     <div class="col-start-2 col-span-4">
       <div id="stars" class="flex flex-row">
-        <%= f.label :star, class: "text-gray-700 mx-2"%>
+        <%= f.label :star, class: "text-gray-700 mx-2" %>
         <%= f.hidden_field :star %>
       </div>
       <script>
@@ -19,7 +19,11 @@
         window.raty(element, opt);
         });
       </script>
-      <%= f.text_area :content, placeholder: "レビューを入力してください",id: 'js-new-review-body', class: 'text-gray-600 bg-gray-50 rounded-lg w-full h-36 my-4 border-gray-400 focus:ring-blue-500 focus:border-blue-500' %></br>
+      <div class="flex items-center my-4">
+        <%= f.label :visit_date, class: "text-gray-600 mx-2" %>
+        <input type="month" name="review[visit_date]" class="bg-gray-50 border border-gray-300 text-gray-600 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5" min="2000-01" max = "<%= Date.today.strftime('%Y-%m') %>">
+      </div>
+      <%= f.text_area :content, placeholder: "レビューを入力してください", id: 'js-new-review-body', class: 'text-gray-600 bg-gray-50 rounded-lg w-full h-36 my-4 border-gray-400 focus:ring-blue-500 focus:border-blue-500' %></br>
     </div>
   </div>
   <div class="flex justify-center">

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -3,9 +3,10 @@
     <div class="flex flex-wrap mt-1 mb-1">
       <%= image_tag review.user.avatar.url, size: '30x30', class: "bg-white rounded-full" %>
       <%= link_to user_path(review.user) do %>
-        <h2 class="mr-4 ml-1 font-bold text-blue-700">🍷<%= review.user.name %>さん</h2>
+        <h2 class="ml-1 font-bold text-blue-700">🍷<%= review.user.name %>さん</h2>
       <% end %>
-      <span><%= l review.created_at, format: :short %></span>
+      <span class="ml-10"><%= l review.created_at, format: :short %></span>
+      <span class="ml-10">訪問時期：<%= review.visit_date ? review.visit_date.strftime("%Y年%m月") : "不明" %>
     </div>
     <div class="ml-10">
       <div id="raty-<%= review.id %>" class="raty-container flex flex-row mb-2">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -47,6 +47,7 @@ ja:
       review:
         content: 'レビュー'
         star: '評価'
+        visit_date: '訪問時期'
   date:
     formats:
       default: "%Y/%m/%d"

--- a/db/migrate/20230927053034_add_visit_date_to_reviews.rb
+++ b/db/migrate/20230927053034_add_visit_date_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddVisitDateToReviews < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reviews, :visit_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_21_054825) do
+ActiveRecord::Schema.define(version: 2023_09_27_053034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2023_09_21_054825) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_id", null: false
     t.float "star", default: 0.0, null: false
+    t.date "visit_date"
     t.index ["brewery_id"], name: "index_reviews_on_brewery_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end


### PR DESCRIPTION
## 概要
`reviews`テーブルに`visit_date`カラムを追加しレビューに「訪問時期」欄を設けた。
訪問時期は年/月までで、日にちは細かすぎるので入力を求めない。
`visit_date`は`date`型なので日にちは全て1日になるように設定。

## 確認方法
1. 醸造所詳細ページのレビュー表示をご確認ください。「訪問時期」を追加しました。
2. レビュー表示の下のフォームをご確認ください。訪問時期選択フォームを追加しました。

## チェックリスト
- [x] rubocopによるLintチェック
- [x] デベロッパーツールによるUI確認
